### PR TITLE
feat(docker): adds dynamic support for multiple architectures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 FROM node:20.12.1-alpine
 
+ARG TARGETPLATFORM
 ENV WAITDEPS_VERSION 0.0.1
 
-RUN apk update --no-cache \
+RUN ARCH=$(echo ${TARGETPLATFORM} | cut -d '/' -f 2) \
+  && apk update --no-cache \
   && apk add --no-cache wget openssl \
-  && wget -nv -O - https://github.com/fcanela/waitdeps/releases/download/$WAITDEPS_VERSION/waitdeps-$WAITDEPS_VERSION-linux-amd64.tar.gz | tar xzf - -C /usr/local/bin \
+  && wget -nv -O - https://github.com/fcanela/waitdeps/releases/download/$WAITDEPS_VERSION/waitdeps-$WAITDEPS_VERSION-linux-$ARCH.tar.gz | tar xzf - -C /usr/local/bin \
   && apk del wget
 
 USER node

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM node:20.12.1-alpine
 ARG TARGETPLATFORM
 ENV WAITDEPS_VERSION 0.0.1
 
-RUN ARCH=$(echo ${TARGETPLATFORM} | cut -d '/' -f 2) \
+RUN set -o pipefail \
+  && ARCH=$(echo ${TARGETPLATFORM} | cut -d '/' -f 2) \
   && apk update --no-cache \
   && apk add --no-cache wget openssl \
   && wget -nv -O - https://github.com/fcanela/waitdeps/releases/download/$WAITDEPS_VERSION/waitdeps-$WAITDEPS_VERSION-linux-$ARCH.tar.gz | tar xzf - -C /usr/local/bin \


### PR DESCRIPTION
Previous version had `amd64` hardcorded, failing to build under `arm64`. This
commit dynamically gets the architecture from the `TARGETPLATFORM` ARG
automatically provided by `buildkit` and uses it.

More info: https://docs.docker.com/reference/dockerfile/#automatic-platform-args-in-the-global-scope

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Dockerfile to automatically detect target platform architecture and fetch the appropriate version of the tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->