### PR TITLE
feat(shutdown): stops heartbeats on shutdown

### DIFF
--- a/src/services/heartbeat.ts
+++ b/src/services/heartbeat.ts
@@ -1,10 +1,17 @@
-import EventEmitter from "node:events";
-import { env } from "../utils/env";
-import { defaultEmitter } from "../utils/emitter";
+import type EventEmitter from "node:events";
 import { BotEventNames } from "../bot-events";
+import { defaultEmitter } from "../utils/emitter";
+import { env } from "../utils/env";
 
 export let interval: NodeJS.Timeout | undefined;
 
+/**
+ * Periodically perform a HTTP GET request to the configured HEARTBEAT_URL.
+ *
+ * @example
+ *
+ * initialize();
+ */
 export const initialize = () => configurableInitialize({ env, emitter: defaultEmitter });
 
 type ConfigurableInitializeDeps = {
@@ -31,4 +38,12 @@ export const configurableInitialize = (deps: ConfigurableInitializeDeps) => {
   }, HEARTBEAT_INTERVAL);
 
   emitter.emit(BotEventNames.HEARTBEAT_READY);
+};
+
+/**
+ * Cancels the periodic heartbeat request.
+ */
+export const stop = () => {
+  clearInterval(interval);
+  interval = undefined;
 };

--- a/src/utils/shutdown.test.ts
+++ b/src/utils/shutdown.test.ts
@@ -32,13 +32,16 @@ describe("Graceful Shutdown", () => {
 
     it("should disconnect the database", async () => {
       const connection = connect(env.DB_URI);
+      const stopHeartbeat = sinon.spy();
 
       await fn({
         connection,
         disconnectDBFn: disconnect,
+        stopHeartbeatFn: stopHeartbeat,
       });
 
-      await expect(test(connection), "stops working after close").to.eventually.be.rejected;
+      expect(stopHeartbeat.calledOnce, "stopHeartbeat not called").to.be.true;
+      await expect(test(connection), "DB still available").to.eventually.be.rejected;
     });
   });
 });

--- a/src/utils/shutdown.ts
+++ b/src/utils/shutdown.ts
@@ -1,6 +1,7 @@
 import EventEmitter from "node:events";
 import { BotEventNames } from "../bot-events";
 import { DBConnection, disconnect as disconnectDB, getConnection as getDBConnection } from "../services/db/connection";
+import { stop as stopHeartbeat } from "../services/heartbeat";
 import { defaultEmitter } from "./emitter";
 
 /**
@@ -50,16 +51,19 @@ export const configurableInitialize = (deps: ConfigurableInitializeDeps) => {
  */
 const stopServices = () => {
   return configurableStopServices({
-    disconnectDBFn: disconnectDB,
     connection: getDBConnection(),
+    disconnectDBFn: disconnectDB,
+    stopHeartbeatFn: stopHeartbeat,
   });
 };
 
 type ConfigurableStopServicesDeps = {
   disconnectDBFn: typeof disconnectDB;
+  stopHeartbeatFn: typeof stopHeartbeat;
   connection: DBConnection;
 };
 export const configurableStopServices = async (deps: ConfigurableStopServicesDeps) => {
-  const { connection, disconnectDBFn } = deps;
+  const { connection, disconnectDBFn, stopHeartbeatFn } = deps;
   await disconnectDBFn(connection);
+  stopHeartbeatFn();
 };


### PR DESCRIPTION
Stops the periodic heartbeats when reaching the final step of the graceful shutdown
process. This ensures there is nothing holding up the shutdown.

As both PRs advanced in parallel the features could not be integrated before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a heartbeat functionality with periodic HTTP GET requests.

- **Bug Fixes**
  - Enhanced graceful shutdown process to ensure heartbeat is properly stopped.

- **Tests**
  - Updated tests to verify the heartbeat stop functionality and ensure proper shutdown procedures.

- **Chores**
  - Refined import statements and improved internal function management for better code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->