### PR TITLE
feat: allows providing a module address

### DIFF
--- a/src/services/reality/index.integration-test.ts
+++ b/src/services/reality/index.integration-test.ts
@@ -32,11 +32,18 @@ describe("Reality", () => {
 
   describe("getSpaceAddresses", () => {
     it("should return both module and oracle contract addresses", async () => {
-      const result = await getSpaceAddresses("1inch.eth");
+      const result = await getSpaceAddresses({ spaceId: "1inch.eth" });
       expect(result).to.eql({
         moduleAddress: ONEINCH_MODULE_ADDRESS,
         oracleAddress: ONEINCH_ORACLE_ADDRESS,
       });
+    });
+
+    it("should only resolve the oracle when the module is provided", async () => {
+      const moduleAddress = "0x6eaB9b5c4Be8F66fC8efb0FdF256FC9143344885";
+      const oracleAddress = "0x5b7dD1E86623548AF054A4985F7fc8Ccbb554E2c";
+      const result = await getSpaceAddresses({ spaceId: "1inch.eth", moduleAddress });
+      expect(result).to.eql({ moduleAddress, oracleAddress });
     });
 
     it("should fail when the module address can't be resolved", async () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,4 +6,4 @@ export type Space = {
   lastProcessedBlock?: bigint | null;
 } & SpaceAddresses;
 
-export type ParsedSpace = Pick<Space, "ens" | "startBlock">;
+export type ParsedSpace = Pick<Space, "ens" | "startBlock"> & Partial<Pick<Space, "moduleAddress">>;

--- a/src/utils/env.test.ts
+++ b/src/utils/env.test.ts
@@ -34,11 +34,12 @@ describe("Environment variables lib", () => {
 
     it("should correctly parse the spaces format with only entry", () => {
       const result = fn("kleros.eth:3000");
+
       expect(result).to.have.lengthOf(1);
-      expect(result[0]).to.eql({
-        ens: "kleros.eth",
-        startBlock: 3000n,
-      });
+      const parsedSpace = result[0];
+      expect(parsedSpace.ens).to.equal("kleros.eth");
+      expect(parsedSpace.startBlock).to.equal(3000n);
+      expect(parsedSpace.moduleAddress).to.be.undefined;
     });
 
     it("should correctly parse the spaces format with multiple entries", () => {
@@ -48,12 +49,24 @@ describe("Environment variables lib", () => {
         {
           ens: "kleros.eth",
           startBlock: 3000n,
+          moduleAddress: undefined,
         },
         {
           ens: "kleros2.eth",
           startBlock: 4000n,
+          moduleAddress: undefined,
         },
       ]);
+    });
+
+    it("should correctly parse an space with module address provided", () => {
+      const result = fn("kleros.eth:3000:0x1234567890abcdef1234567890abcdef12345678");
+      expect(result).to.have.lengthOf(1);
+      expect(result[0]).to.eql({
+        ens: "kleros.eth",
+        startBlock: 3000n,
+        moduleAddress: "0x1234567890abcdef1234567890abcdef12345678",
+      });
     });
   });
 


### PR DESCRIPTION
In addition to autoresolving the contracts from the Snapshot SpaceID, the bot
also allows providing a fixed module contract address.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for specifying an optional Reality Module address in the environment variable for spaces.

- **Bug Fixes**
  - Improved parsing logic for spaces format to handle entries with and without module addresses correctly.

- **Refactor**
  - Updated space handling logic to use a new structured object format for better flexibility and clarity.

- **Tests**
  - Added new test cases to verify functionality with and without module addresses in spaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->