### PR TITLE
feat: formats difficult to read values in templates

### DIFF
--- a/src/utils/format.test.ts
+++ b/src/utils/format.test.ts
@@ -1,0 +1,68 @@
+import { Hex } from "viem";
+import { formatAnswer, formatWei } from "./format";
+import { expect } from "./tests-setup";
+
+describe("formatWei", () => {
+  const fn = formatWei;
+
+  it("should display small amounts in wei", () => {
+    expect(fn(1n)).to.eql("1 wei");
+    expect(fn(10n)).to.eql("10 wei");
+    expect(fn(100n)).to.eql("100 wei");
+    expect(fn(1_000n)).to.eql("1000 wei");
+    expect(fn(10_000n)).to.eql("10000 wei");
+    expect(fn(100_000n)).to.eql("100000 wei");
+    expect(fn(1_000_000n)).to.eql("1000000 wei");
+    expect(fn(9_999_999n)).to.eql("9999999 wei");
+  });
+
+  it("should correctly humanize close to the gwei", () => {
+    expect(fn(10_000_000n)).to.eql("0.01 gwei");
+    expect(fn(100_000_000n)).to.eql("0.1 gwei");
+    expect(fn(1_000_000_000n)).to.eql("1 gwei");
+    expect(fn(1_500_000_000n)).to.eql("1.5 gwei");
+    expect(fn(10_000_000_000n)).to.eql("10 gwei");
+    expect(fn(100_000_000_000n)).to.eql("100 gwei");
+    expect(fn(1_000_000_000_000n)).to.eql("1000 gwei");
+    expect(fn(10_000_000_000_000n)).to.eql("10000 gwei");
+    expect(fn(100_000_000_000_000n)).to.eql("100000 gwei");
+    expect(fn(1_000_000_000_000_000n)).to.eql("1000000 gwei");
+    expect(fn(9_999_999_999_999_999n)).to.eql("9999999.999999999 gwei");
+  });
+
+  it("should correctly humanize units close to the ether", () => {
+    expect(fn(10_000_000_000_000_000n)).to.eql("0.01 ether");
+    expect(fn(100_000_000_000_000_000n)).to.eql("0.1 ether");
+    expect(fn(1_000_000_000_000_000_000n)).to.eql("1 ether");
+    expect(fn(1_256_000_000_000_000_000n)).to.eql("1.256 ether");
+    expect(fn(1_500_000_000_000_000_000n)).to.eql("1.5 ether");
+    expect(fn(10_000_000_000_000_000_000n)).to.eql("10 ether");
+    expect(fn(100_000_000_000_000_000_000n)).to.eql("100 ether");
+  });
+});
+
+describe("formatAnswer", () => {
+  const fn = formatAnswer;
+
+  it("should return 'Approved' for the hex value '0x1'", () => {
+    expect(fn("0x1")).to.equal("Approved");
+    expect(fn("0x01")).to.equal("Approved");
+    expect(fn("0x0000000000000000000000000001")).to.equal("Approved");
+    expect(fn("0x0000000000000000000000000001")).to.equal("Approved");
+    expect(fn("0X1" as Hex)).to.equal("Approved");
+  });
+
+  it("should return 'Rejected' for the hex value '0x0'", () => {
+    expect(fn("0x0")).to.equal("Rejected");
+    expect(fn("0x00")).to.equal("Rejected");
+    expect(fn("0x0000000000000000000000000000")).to.equal("Rejected");
+    expect(fn("0X0" as Hex)).to.equal("Rejected");
+  });
+
+  it("should return the original hex value for unexpected values", () => {
+    expect(fn("0x2")).to.equal("0x2");
+    expect(fn("0x00000000000000000000000000002")).to.equal("0x00000000000000000000000000002");
+    expect(fn("0x3")).to.equal("0x3");
+    expect(fn("0xffff")).to.equal("0xffff");
+  });
+});

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,0 +1,52 @@
+import { formatEther, formatGwei, Hex } from "viem";
+
+/**
+ * Converts a wei amount to a human-readable string in wei, gwei, or ether.
+ *
+ * - Values less than 0.01 gwei are displayed in wei.
+ * - Values from 0.01 gwei up to 0.01 ether are displayed in gwei.
+ * - Values equal to or greater than 0.01 ether are displayed in ether.
+ *
+ * @param {bigint} wei - The amount in wei to be converted.
+ * @returns {string} - The human-readable string representation of the wei amount.
+ *
+ * @example
+ * formatWei(1_000n); // "1000 wei"
+ * formatWei(10_000_000n); // "0.01 gwei"
+ * formatWei(100_0000_000n); // "1 gwei"
+ * formatWei(100_000_000_000_000_000n); // "0.1 ether"
+ * formatWei(1_000_000_000_000_000_000n); // "1 ether"
+ */
+
+export const formatWei = (wei: bigint): string => {
+  const digitCount = wei.toString().length;
+
+  if (digitCount < 8) return `${wei.toString()} wei`;
+  if (digitCount < 17) return `${formatGwei(wei)} gwei`;
+  return `${formatEther(wei)} ether`;
+};
+
+/**
+ * Transforms a Reality Oracle answer to a human-readable string. Returns the original
+ * answer when it is not an expected value.
+ *
+ * Reality Oracle Answers provide a hexadecimal value of '0x0' or '0x1' to represent
+ * rejection or approval respectively.
+ *
+ * @param answer - The hex value representing the Reality Oracle answer.
+ * @returns The human-readable string "Approved" or "Rejected", or the original
+ * hex value if it is not '0x0' or '0x1'.
+ *
+ * @example
+ * formatAnswer('0x1'); // "Approved"
+ * formatAnswer('0x0'); // "Rejected"
+ * formatAnswer('0x2'); // "0x2"
+ */
+export const formatAnswer = (answer: Hex): string => {
+  const num = parseInt(answer, 16);
+
+  if (num == 1) return "Approved";
+  if (num == 0) return "Rejected";
+
+  return answer;
+};

--- a/src/utils/notification-template.ts
+++ b/src/utils/notification-template.ts
@@ -1,6 +1,7 @@
 import { join, normalize } from "node:path";
 import ejs from "ejs";
 import type { TransportName, Notification, EventType } from "../notify";
+import { formatAnswer, formatWei } from "./format";
 
 const BASE_TEMPLATES_PATH = normalize(join(__dirname, "../../templates"));
 
@@ -43,7 +44,7 @@ export const render = (transport: TransportName, notification: Notification, var
   const path = join(BASE_TEMPLATES_PATH, getTemplateFilePath(transport, notification.type, variant));
   return ejs.renderFile(
     path,
-    { notification },
+    { notification, formatWei, formatAnswer },
     {
       cache: true,
       async: true,

--- a/templates/email/answer-issued-html.ejs
+++ b/templates/email/answer-issued-html.ejs
@@ -102,11 +102,11 @@
         </p>
         <p>
           <strong>Bond:</strong>
-          <span class="code"><%- notification.event.bond %></span>
+          <span class="code"><%- formatWei(notification.event.bond) %></span>
         </p>
         <p>
           <strong>Answer:</strong>
-          <span class="code"><%- notification.event.answer %></span>
+          <span class="code"><%- formatAnswer(notification.event.answer) %></span>
         </p>
       </div>
       <div class="footer">

--- a/templates/email/answer-issued-plain.ejs
+++ b/templates/email/answer-issued-plain.ejs
@@ -15,8 +15,8 @@ You can explore the transaction details on Etherscan using the following links:
 
 The event contained the following information:
 - Question ID: <%- notification.event.questionId %>
-- Bond: <%- notification.event.bond %>
-- Answer: <%- notification.event.answer %>
+- Bond: <%- formatWei(notification.event.bond) %>
+- Answer: <%- formatAnswer(notification.event.answer) %>
 
 Best regards,
 Kleros Zodiac Notifications Bot

--- a/templates/slack/answer-issued.ejs
+++ b/templates/slack/answer-issued.ejs
@@ -7,5 +7,5 @@
 
 *Event:*
 _Question ID_: `<%- notification.event.questionId %>`
-_Bond_: `<%- notification.event.bond %>`
-_Answer_: `<%- notification.event.answer %>`
+_Bond_: `<%- formatWei(notification.event.bond) %>`
+_Answer_: `<%- formatAnswer(notification.event.answer) %>`

--- a/templates/telegram/answer-issued.ejs
+++ b/templates/telegram/answer-issued.ejs
@@ -16,6 +16,6 @@ _User_
 _Question ID_
 `<%- notification.event.questionId %>`
 _Bond_
-`<%- notification.event.bond %>`
+`<%- formatWei(notification.event.bond) %>`
 _Answer_
-`<%- notification.event.answer %>`
+`<%- formatAnswer(notification.event.answer) %>`


### PR DESCRIPTION
Oracle answers and bonds are not easy to read. This transforms:
- Answers like 0x000...001 to `Approved`
- Bonds like 10000000000000000 to `0.01 ether`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced email, Slack, and Telegram templates to display formatted bond and answer values for better readability.

- **Improvements**
  - Introduced `formatWei` and `formatAnswer` functions to convert raw data into human-readable formats, improving the clarity of information presented to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->