### PR TITLE
fix: filters oracle notifications per space

### DIFF
--- a/migrations/0002_proposal_initial.sql
+++ b/migrations/0002_proposal_initial.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS "proposal" (
+	"proposal_id" varchar(66) PRIMARY KEY NOT NULL,
+	"question_id" varchar(66) NOT NULL,
+	"ens" varchar NOT NULL,
+	"tx_hash" varchar(66) NOT NULL,
+	"happened_at" timestamp NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "question_idx" ON "proposal" ("question_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "ens_idx" ON "proposal" ("ens");--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "proposal" ADD CONSTRAINT "proposal_ens_space_ens_fk" FOREIGN KEY ("ens") REFERENCES "space"("ens") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/migrations/meta/0002_snapshot.json
+++ b/migrations/meta/0002_snapshot.json
@@ -1,0 +1,171 @@
+{
+  "id": "4ac8000c-14c3-4541-9bae-1cb4d3767dd2",
+  "prevId": "4ad79953-df56-4304-92bf-b922779e84be",
+  "version": "5",
+  "dialect": "pg",
+  "tables": {
+    "notification": {
+      "name": "notification",
+      "schema": "",
+      "columns": {
+        "tx_hash": {
+          "name": "tx_hash",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block": {
+          "name": "block",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transport_name": {
+          "name": "transport_name",
+          "type": "transport_name",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "notification_tx_hash_transport_name_pk": {
+          "name": "notification_tx_hash_transport_name_pk",
+          "columns": [
+            "tx_hash",
+            "transport_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "proposal": {
+      "name": "proposal",
+      "schema": "",
+      "columns": {
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "varchar(66)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ens": {
+          "name": "ens",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tx_hash": {
+          "name": "tx_hash",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "happened_at": {
+          "name": "happened_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "question_idx": {
+          "name": "question_idx",
+          "columns": [
+            "question_id"
+          ],
+          "isUnique": false
+        },
+        "ens_idx": {
+          "name": "ens_idx",
+          "columns": [
+            "ens"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "proposal_ens_space_ens_fk": {
+          "name": "proposal_ens_space_ens_fk",
+          "tableFrom": "proposal",
+          "tableTo": "space",
+          "columnsFrom": [
+            "ens"
+          ],
+          "columnsTo": [
+            "ens"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "space": {
+      "name": "space",
+      "schema": "",
+      "columns": {
+        "ens": {
+          "name": "ens",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "start_block": {
+          "name": "start_block",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_processed_block": {
+          "name": "last_processed_block",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {
+    "transport_name": {
+      "name": "transport_name",
+      "values": {
+        "telegram": "telegram",
+        "slack": "slack",
+        "email": "email"
+      }
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1718804158851,
       "tag": "0001_notification_initial",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "5",
+      "when": 1721384790855,
+      "tag": "0002_proposal_initial",
+      "breakpoints": true
     }
   ]
 }

--- a/src/processing.integration-test.ts
+++ b/src/processing.integration-test.ts
@@ -1,18 +1,21 @@
 import { EventEmitter } from "node:events";
 import { spy } from "sinon";
-import { EventType, Notification } from "./notify";
-import { configurableProcessSpace } from "./processing";
+import type { Hash } from "viem";
+import { EventType, type Notification } from "./notify";
+import { configurableProcessAnswers, configurableProcessProposals, configurableProcessSpace } from "./processing";
+import { findProposalByQuestionId, insertProposal } from "./services/db/proposals";
 import { findSpaces, insertSpaces, updateSpace } from "./services/db/spaces";
-import { Space } from "./types";
+import type { LogNewAnswer, ProposalQuestionCreated } from "./services/reality";
+import type { Space } from "./types";
+import { getRandomHash, randomizeAnswerEventField, randomizeEns, randomizeSpace } from "./utils/test-mocks";
 import { ONEINCH_MODULE_ADDRESS, ONEINCH_ORACLE_ADDRESS, expect } from "./utils/tests-setup";
-
-const generateRandomEns = () => `test${Math.floor(Math.random() * 1000000)}.eth`;
+import { random } from "lodash";
 
 describe("processSpace", () => {
   const fn = configurableProcessSpace;
 
   const space: Space = {
-    ens: generateRandomEns(),
+    ens: randomizeEns(),
     startBlock: 1n,
     lastProcessedBlock: 19475120n,
     moduleAddress: ONEINCH_MODULE_ADDRESS,
@@ -31,7 +34,8 @@ describe("processSpace", () => {
   });
 
   it("should process proposals correctly", async () => {
-    const notifyFn = spy();
+    const processProposalsFn = spy();
+    const processAnswersFn = spy();
     const emitter = new EventEmitter();
 
     const toBlock = 19475121n;
@@ -40,34 +44,41 @@ describe("processSpace", () => {
       space,
       blockNumber: toBlock,
       calculateBlockRangeFn: () => ({
-        fromBlock: 19475120n,
         toBlock,
+        fromBlock: 19475120n,
       }),
       emitter,
-      notifyFn,
       updateSpaceFn: updateSpace,
+      processProposalsFn,
+      processAnswersFn,
     });
 
     expect(result.lastProcessedBlock).to.equal(toBlock);
-    expect(notifyFn.calledOnce).to.be.true;
-    const call = notifyFn.firstCall.firstArg;
-    expect(call).to.deep.equal({
-      type: EventType.PROPOSAL_QUESTION_CREATED,
-      space,
-      event: {
+
+    expect(processProposalsFn.calledOnce).to.be.true;
+    const processProposalsCall = processProposalsFn.firstCall;
+    expect(processProposalsCall.args[0]).to.deep.equal(space);
+    expect(processProposalsCall.args[1]).to.deep.equal([
+      {
         proposalId: "0x791b3d71ea14497d3b8e756479f6f126e08b44351bfab904834c56b1ccf0479a",
-        questionId: "0xebf5b601fedfaa5562a03590e9ac8be937cc070a131443af01948a7eda6dfabf",
+        questionId: "0xebf5b601fedfaa5562a03590e9ac8be937cc070a131443af01948a7eda6dfabf" as Hash,
         txHash: "0x890ddd7826fcd79ff17b54368e8df393959f269847ceeb0fea13cc4b68330d43",
         blockNumber: 19475120n,
+        happenedAt: new Date("2024-03-20T09:48:23.000Z"),
       },
-    } as Notification);
+    ]);
+
+    expect(processAnswersFn.calledOnce).to.be.true;
+    const processAnswersCall = processAnswersFn.firstCall;
+    expect(processAnswersCall.args[1]).to.have.lengthOf(0);
 
     const [updatedSpace] = await findSpaces([space.ens]);
     expect(updatedSpace.lastProcessedBlock).to.equal(toBlock);
   });
 
   it("should process answers correctly", async () => {
-    const notifyFn = spy();
+    const processProposalsFn = spy();
+    const processAnswersFn = spy();
     const emitter = new EventEmitter();
 
     space.lastProcessedBlock = 19640300n;
@@ -81,28 +92,176 @@ describe("processSpace", () => {
         toBlock,
       }),
       emitter,
-      notifyFn,
       updateSpaceFn: updateSpace,
+      processProposalsFn,
+      processAnswersFn,
     });
 
     expect(result.lastProcessedBlock).to.equal(toBlock);
+
+    expect(processProposalsFn.calledOnce).to.be.true;
+    const processProposalsCall = processProposalsFn.firstCall;
+    expect(processProposalsCall.args[1]).to.have.lengthOf(0);
+
+    expect(processAnswersFn.calledOnce).to.be.true;
+    const processAnswersCall = processAnswersFn.firstCall;
+    expect(processAnswersCall.args[0]).to.deep.equal(space);
+    expect(processAnswersCall.args[1]).to.deep.equal([
+      {
+        questionId: "0x8566ba6b1ac945f2b152a20ecc7cb3a87982190190af14cb4fbc85e12eb474e2",
+        answer: "0x0000000000000000000000000000000000000000000000000000000000000001",
+        user: "0x4D6CAa3E0983fAc7B514D60339EBb538C5A85AAe",
+        bond: 10000000n,
+        txHash: "0x0cc20c32ee428bdb8f16fa1aa22b396ecafa91b61bc2c3350723e4dfefeebff0",
+        blockNumber: 19640300n,
+        happenedAt: new Date(1712934227 * 1000),
+      },
+    ]);
+
+    const [updatedSpace] = await findSpaces([space.ens]);
+    expect(updatedSpace.lastProcessedBlock).to.equal(toBlock);
+  });
+});
+
+describe("processProposals", () => {
+  const fn = configurableProcessProposals;
+
+  const space = randomizeSpace();
+
+  beforeEach(async () => {
+    space.ens = randomizeEns();
+    await insertSpaces([
+      {
+        ens: space.ens,
+        startBlock: 1n,
+        lastProcessedBlock: 1n,
+      },
+    ]);
+  });
+
+  it("should register the proposal and issue a notification", async () => {
+    const notifyFn = spy();
+
+    const proposal: ProposalQuestionCreated = {
+      proposalId: "0x791b3d71ea14497d3b8e756479f6f126e08b44351bfab904834c56b1ccf0479a",
+      questionId: "0xebf5b601fedfaa5562a03590e9ac8be937cc070a131443af01948a7eda6dfabf" as Hash,
+      txHash: "0x890ddd7826fcd79ff17b54368e8df393959f269847ceeb0fea13cc4b68330d43",
+      blockNumber: 19475120n,
+      happenedAt: new Date("2024-03-20T09:48:23.000Z"),
+    };
+
+    await fn({
+      space,
+      proposals: [proposal],
+      notifyFn,
+      insertProposalFn: insertProposal,
+    });
+
+    expect(notifyFn.calledOnce).to.be.true;
+    const call = notifyFn.firstCall.firstArg;
+
+    expect(call).to.deep.equal({
+      type: EventType.PROPOSAL_QUESTION_CREATED,
+      space,
+      event: proposal,
+    } as Notification);
+
+    const storedProposal = await findProposalByQuestionId(proposal.questionId);
+    expect(storedProposal).to.not.be.null;
+  });
+});
+
+describe("processAnswers", () => {
+  const fn = configurableProcessAnswers;
+
+  const space = randomizeSpace();
+
+  beforeEach(async () => {
+    space.ens = randomizeEns();
+    await insertSpaces([
+      {
+        ens: space.ens,
+        startBlock: 1n,
+        lastProcessedBlock: 1n,
+      },
+    ]);
+  });
+
+  it("should issue a notification when is for the current space", async () => {
+    const notifyFn = spy();
+
+    const answer: LogNewAnswer = {
+      questionId: "0x8566ba6b1ac945f2b152a20ecc7cb3a87982190190af14cb4fbc85e12eb474e2",
+      answer: "0x0000000000000000000000000000000000000000000000000000000000000001",
+      user: "0x4D6CAa3E0983fAc7B514D60339EBb538C5A85AAe",
+      bond: 10000000n,
+      txHash: "0x0cc20c32ee428bdb8f16fa1aa22b396ecafa91b61bc2c3350723e4dfefeebff0",
+      blockNumber: 19640300n,
+      happenedAt: new Date(1712934227 * 1000),
+    };
+
+    await insertProposal({
+      ens: space.ens,
+      questionId: answer.questionId,
+      proposalId: getRandomHash(),
+      txHash: getRandomHash(),
+      happenedAt: new Date("2024-03-20T09:48:23.000Z"),
+    });
+
+    await fn({
+      space,
+      answers: [answer],
+      notifyFn,
+      findProposalByQuestionIdFn: findProposalByQuestionId,
+    });
+
     expect(notifyFn.calledOnce).to.be.true;
     const call = notifyFn.firstCall.firstArg;
     expect(call).to.deep.equal({
       type: EventType.NEW_ANSWER,
       space,
-      event: {
-        questionId: "0x8566ba6b1ac945f2b152a20ecc7cb3a87982190190af14cb4fbc85e12eb474e2",
-        answer: "0x0000000000000000000000000000000000000000000000000000000000000001",
-        user: "0x4D6CAa3E0983fAc7B514D60339EBb538C5A85AAe",
-        bond: 10000000n,
-        ts: 1712934227,
-        txHash: "0x0cc20c32ee428bdb8f16fa1aa22b396ecafa91b61bc2c3350723e4dfefeebff0",
-        blockNumber: 19640300n,
-      },
+      event: answer,
     } as Notification);
+  });
 
-    const [updatedSpace] = await findSpaces([space.ens]);
-    expect(updatedSpace.lastProcessedBlock).to.equal(toBlock);
+  it("should ignore events that do not correspond to existing proposals", async () => {
+    const notifyFn = spy();
+
+    const answer = randomizeAnswerEventField();
+
+    await fn({
+      space,
+      answers: [answer],
+      notifyFn,
+      findProposalByQuestionIdFn: findProposalByQuestionId,
+    });
+
+    expect(notifyFn.called).to.be.false;
+  });
+
+  it("should ignore events that do not correspond to existing space", async () => {
+    const notifyFn = spy();
+
+    const answer = randomizeAnswerEventField();
+
+    const proposalSpace = randomizeSpace();
+    await insertSpaces([proposalSpace]);
+
+    await insertProposal({
+      ens: proposalSpace.ens,
+      questionId: answer.questionId,
+      proposalId: getRandomHash(),
+      txHash: getRandomHash(),
+      happenedAt: new Date("2024-03-20T09:48:23.000Z"),
+    });
+
+    await fn({
+      space,
+      answers: [answer],
+      notifyFn,
+      findProposalByQuestionIdFn: findProposalByQuestionId,
+    });
+
+    expect(notifyFn.called).to.be.false;
   });
 });

--- a/src/processing.integration-test.ts
+++ b/src/processing.integration-test.ts
@@ -46,8 +46,8 @@ describe("processSpace", () => {
       space,
       blockNumber: toBlock,
       calculateBlockRangeFn: () => ({
-        toBlock,
         fromBlock: oneInchProposalBlockNumber,
+        toBlock,
       }),
       emitter,
       updateSpaceFn: updateSpace,

--- a/src/processing.integration-test.ts
+++ b/src/processing.integration-test.ts
@@ -9,7 +9,9 @@ import type { LogNewAnswer, ProposalQuestionCreated } from "./services/reality";
 import type { Space } from "./types";
 import { getRandomHash, randomizeAnswerEventField, randomizeEns, randomizeSpace } from "./utils/test-mocks";
 import { ONEINCH_MODULE_ADDRESS, ONEINCH_ORACLE_ADDRESS, expect } from "./utils/tests-setup";
-import { random } from "lodash";
+
+const oneInchProposalBlockNumber = 19475120n;
+const oneInchAnswerBlockNumber = 19640300n;
 
 describe("processSpace", () => {
   const fn = configurableProcessSpace;
@@ -17,7 +19,7 @@ describe("processSpace", () => {
   const space: Space = {
     ens: randomizeEns(),
     startBlock: 1n,
-    lastProcessedBlock: 19475120n,
+    lastProcessedBlock: oneInchProposalBlockNumber,
     moduleAddress: ONEINCH_MODULE_ADDRESS,
     oracleAddress: ONEINCH_ORACLE_ADDRESS,
   };
@@ -38,14 +40,14 @@ describe("processSpace", () => {
     const processAnswersFn = spy();
     const emitter = new EventEmitter();
 
-    const toBlock = 19475121n;
+    const toBlock = oneInchProposalBlockNumber + 1n;
 
     const result = await fn({
       space,
       blockNumber: toBlock,
       calculateBlockRangeFn: () => ({
         toBlock,
-        fromBlock: 19475120n,
+        fromBlock: oneInchProposalBlockNumber,
       }),
       emitter,
       updateSpaceFn: updateSpace,
@@ -63,7 +65,7 @@ describe("processSpace", () => {
         proposalId: "0x791b3d71ea14497d3b8e756479f6f126e08b44351bfab904834c56b1ccf0479a",
         questionId: "0xebf5b601fedfaa5562a03590e9ac8be937cc070a131443af01948a7eda6dfabf" as Hash,
         txHash: "0x890ddd7826fcd79ff17b54368e8df393959f269847ceeb0fea13cc4b68330d43",
-        blockNumber: 19475120n,
+        blockNumber: oneInchProposalBlockNumber,
         happenedAt: new Date("2024-03-20T09:48:23.000Z"),
       },
     ]);
@@ -81,8 +83,8 @@ describe("processSpace", () => {
     const processAnswersFn = spy();
     const emitter = new EventEmitter();
 
-    space.lastProcessedBlock = 19640300n;
-    const toBlock = 19640301n;
+    space.lastProcessedBlock = oneInchAnswerBlockNumber;
+    const toBlock = space.lastProcessedBlock + 1n;
 
     const result = await fn({
       space,
@@ -113,7 +115,7 @@ describe("processSpace", () => {
         user: "0x4D6CAa3E0983fAc7B514D60339EBb538C5A85AAe",
         bond: 10000000n,
         txHash: "0x0cc20c32ee428bdb8f16fa1aa22b396ecafa91b61bc2c3350723e4dfefeebff0",
-        blockNumber: 19640300n,
+        blockNumber: oneInchAnswerBlockNumber,
         happenedAt: new Date(1712934227 * 1000),
       },
     ]);
@@ -146,7 +148,7 @@ describe("processProposals", () => {
       proposalId: "0x791b3d71ea14497d3b8e756479f6f126e08b44351bfab904834c56b1ccf0479a",
       questionId: "0xebf5b601fedfaa5562a03590e9ac8be937cc070a131443af01948a7eda6dfabf" as Hash,
       txHash: "0x890ddd7826fcd79ff17b54368e8df393959f269847ceeb0fea13cc4b68330d43",
-      blockNumber: 19475120n,
+      blockNumber: oneInchProposalBlockNumber,
       happenedAt: new Date("2024-03-20T09:48:23.000Z"),
     };
 
@@ -196,7 +198,7 @@ describe("processAnswers", () => {
       user: "0x4D6CAa3E0983fAc7B514D60339EBb538C5A85AAe",
       bond: 10000000n,
       txHash: "0x0cc20c32ee428bdb8f16fa1aa22b396ecafa91b61bc2c3350723e4dfefeebff0",
-      blockNumber: 19640300n,
+      blockNumber: oneInchAnswerBlockNumber,
       happenedAt: new Date(1712934227 * 1000),
     };
 

--- a/src/processing.ts
+++ b/src/processing.ts
@@ -251,11 +251,11 @@ type ConfigurableProcessAnswersDeps = {
   findProposalByQuestionIdFn: typeof findProposalByQuestionId;
 };
 export const configurableProcessAnswers = async (deps: ConfigurableProcessAnswersDeps) => {
-  const { space, answers, notifyFn } = deps;
+  const { space, answers, notifyFn, findProposalByQuestionIdFn } = deps;
 
   await Promise.all(
     answers.map(async (event) => {
-      const proposal = await deps.findProposalByQuestionIdFn(event.questionId);
+      const proposal = await findProposalByQuestionIdFn(event.questionId);
 
       if (!proposal || proposal.ens !== space.ens) return;
 

--- a/src/processing.ts
+++ b/src/processing.ts
@@ -1,12 +1,23 @@
-import type { EventEmitter } from "node:events";
-import { BotEventNames, SpaceDetailedPayload, SpaceSkippedPayload, SpaceStartedPayload } from "./bot-events";
+import {
+  BotEventNames,
+  type SpaceDetailedPayload,
+  type SpaceSkippedPayload,
+  type SpaceStartedPayload,
+} from "./bot-events";
 import { EventType, notify } from "./notify";
+import { findProposalByQuestionId, insertProposal } from "./services/db/proposals";
 import { updateSpace } from "./services/db/spaces";
 import { getPublicClient } from "./services/provider";
-import { getLogNewAnswer, getProposalQuestionsCreated } from "./services/reality";
-import { Space } from "./types";
+import {
+  getLogNewAnswer,
+  getProposalQuestionsCreated,
+  type LogNewAnswer,
+  type ProposalQuestionCreated,
+} from "./services/reality";
 import { defaultEmitter } from "./utils/emitter";
 import { env } from "./utils/env";
+import type { EventEmitter } from "node:events";
+import type { Space } from "./types";
 
 /**
  * Process all spaces, respecting the batch size. Triggers a notification per event. Returns the
@@ -57,7 +68,8 @@ export const processSpace = async (space: Space, blockNumber: bigint) => {
     emitter: defaultEmitter,
     calculateBlockRangeFn: calculateBlockRange,
     updateSpaceFn: updateSpace,
-    notifyFn: notify,
+    processProposalsFn: processProposals,
+    processAnswersFn: processAnswers,
   });
 };
 
@@ -67,10 +79,12 @@ type ConfigurableProcessSpaceDeps = {
   emitter: EventEmitter;
   calculateBlockRangeFn: typeof calculateBlockRange;
   updateSpaceFn: typeof updateSpace;
-  notifyFn: typeof notify;
+  processProposalsFn: typeof processProposals;
+  processAnswersFn: typeof processAnswers;
 };
 export const configurableProcessSpace = async (deps: ConfigurableProcessSpaceDeps): Promise<Space> => {
-  const { space, blockNumber, calculateBlockRangeFn, emitter, updateSpaceFn, notifyFn } = deps;
+  const { space, blockNumber, calculateBlockRangeFn, emitter, updateSpaceFn, processProposalsFn, processAnswersFn } =
+    deps;
 
   emitter.emit(BotEventNames.SPACE_STARTED, { space } satisfies SpaceStartedPayload);
 
@@ -104,24 +118,10 @@ export const configurableProcessSpace = async (deps: ConfigurableProcessSpaceDep
   };
   emitter.emit(BotEventNames.SPACE_EVENTS_FETCHED, emittedContext);
 
-  if (proposals.length !== 0 || answers.length !== 0) {
-    await Promise.all([
-      ...proposals.map((event) =>
-        notifyFn({
-          type: EventType.PROPOSAL_QUESTION_CREATED,
-          event,
-          space,
-        }),
-      ),
-      ...answers.map((event) =>
-        notifyFn({
-          type: EventType.NEW_ANSWER,
-          event,
-          space,
-        }),
-      ),
-    ]);
+  await processProposalsFn(space, proposals);
+  await processAnswersFn(space, answers);
 
+  if (proposals.length !== 0 || answers.length !== 0) {
     emitter.emit(BotEventNames.SPACE_NOTIFIED, emittedContext);
   }
 
@@ -177,3 +177,93 @@ export const min = (a: bigint, b: bigint) => (a < b ? a : b);
  * const biggest = max(5n, 10n) // 10n
  */
 export const max = (a: bigint, b: bigint) => (a > b ? a : b);
+
+/**
+ * Register the proposals as as active (to enable later identification
+ * of answers) and issue notifications for them.
+ *
+ * @param space - The space that the proposals belong to
+ * @param proposals - The proposals to process
+ *
+ * @example
+ * await processProposals(space, proposals)
+ */
+export const processProposals = (space: Space, proposals: ProposalQuestionCreated[]) => {
+  return configurableProcessProposals({
+    space,
+    proposals,
+    notifyFn: notify,
+    insertProposalFn: insertProposal,
+  });
+};
+
+type ConfigurableProcessProposalsDeps = {
+  space: Space;
+  proposals: ProposalQuestionCreated[];
+  notifyFn: typeof notify;
+  insertProposalFn: typeof insertProposal;
+};
+export const configurableProcessProposals = async (deps: ConfigurableProcessProposalsDeps) => {
+  const { space, proposals, insertProposalFn, notifyFn } = deps;
+
+  await Promise.all(
+    proposals.map((event) =>
+      Promise.all([
+        insertProposalFn({
+          ens: space.ens,
+          proposalId: event.proposalId,
+          txHash: event.txHash,
+          questionId: event.questionId,
+          happenedAt: event.happenedAt,
+        }),
+        notifyFn({
+          type: EventType.PROPOSAL_QUESTION_CREATED,
+          event,
+          space,
+        }),
+      ]),
+    ),
+  );
+};
+
+/**
+ * Notifies the answers, ignoring those not issued for the current space
+ *
+ * @param space - The space that the answers belong to
+ * @param answers - The answers to process
+ *
+ * @example
+ * await processAnswers(space, answers)
+ */
+export const processAnswers = (space: Space, answers: LogNewAnswer[]) => {
+  return configurableProcessAnswers({
+    space,
+    answers,
+    notifyFn: notify,
+    findProposalByQuestionIdFn: findProposalByQuestionId,
+  });
+};
+
+type ConfigurableProcessAnswersDeps = {
+  space: Space;
+  answers: LogNewAnswer[];
+  notifyFn: typeof notify;
+  findProposalByQuestionIdFn: typeof findProposalByQuestionId;
+};
+export const configurableProcessAnswers = async (deps: ConfigurableProcessAnswersDeps) => {
+  const { space, answers, notifyFn } = deps;
+
+  await Promise.all(
+    answers.map(async (event) => {
+      const proposal = await deps.findProposalByQuestionIdFn(event.questionId);
+
+      if (!proposal || proposal.ens !== space.ens) return;
+
+      await notifyFn({
+        type: EventType.NEW_ANSWER,
+        event,
+        space,
+      });
+    }),
+  );
+};

--- a/src/services/db/proposal.integration-test.ts
+++ b/src/services/db/proposal.integration-test.ts
@@ -1,0 +1,92 @@
+import { eq } from "drizzle-orm";
+import type { Hash } from "viem";
+import type { ProposalNotification } from "../../notify";
+import type { Space } from "../../types";
+import { randomizeProposalNotification, randomizeSpace } from "../../utils/test-mocks";
+import { expect } from "../../utils/tests-setup";
+import { getConnection } from "./connection";
+import {
+  type InsertableProposal,
+  findProposalByQuestionId,
+  insertProposal,
+  removeProposalByQuestionId,
+} from "./proposals";
+import * as schema from "./schema";
+import { insertSpaces } from "./spaces";
+
+describe("Active Proposals model", () => {
+  const { db } = getConnection();
+
+  let space: Space;
+  before(async () => {
+    space = randomizeSpace();
+    await insertSpaces([space]);
+  });
+
+  const randomizeProposal = (notification: ProposalNotification): InsertableProposal => ({
+    ens: notification.space.ens,
+    questionId: notification.event.questionId,
+    proposalId: notification.event.proposalId,
+    txHash: notification.event.txHash,
+    happenedAt: notification.event.happenedAt,
+  });
+  describe("insertProposal", () => {
+    const fn = insertProposal;
+
+    it("should insert a proposal", async () => {
+      const notification = randomizeProposalNotification({ space });
+      const fields = randomizeProposal(notification);
+      await fn(fields);
+
+      const inserted = await db.select().from(schema.proposal).where(eq(schema.proposal.questionId, fields.questionId));
+
+      expect(inserted).to.be.length(1);
+
+      const storedProposal = inserted[0];
+      expect(storedProposal.createdAt).to.exist;
+      expect(storedProposal).to.eql({
+        ...fields,
+        createdAt: storedProposal.createdAt,
+      });
+    });
+  });
+
+  describe("findProposalByQuestionId", () => {
+    const fn = findProposalByQuestionId;
+
+    it("should return an existing proposal", async () => {
+      const notification = randomizeProposalNotification({ space });
+      const fields = randomizeProposal(notification);
+      await insertProposal(fields);
+
+      const result = await fn(fields.questionId as Hash);
+
+      expect(result).to.be.not.null;
+
+      const { createdAt, ...proposal } = result!;
+      expect(createdAt).to.exist;
+      expect(proposal).to.eql(fields);
+    });
+
+    it("should return null if it does not exist", async () => {
+      const result = await fn("0xtest");
+
+      expect(result).to.be.null;
+    });
+  });
+
+  describe("removeProposal", () => {
+    const fn = removeProposalByQuestionId;
+
+    it("should return an existing proposal", async () => {
+      const notification = randomizeProposalNotification({ space });
+      const fields = randomizeProposal(notification);
+      await insertProposal(fields);
+
+      await fn(fields.questionId as Hash);
+
+      const found = await findProposalByQuestionId(fields.questionId as Hash);
+      expect(found).to.be.null;
+    });
+  });
+});

--- a/src/services/db/proposals.ts
+++ b/src/services/db/proposals.ts
@@ -1,0 +1,61 @@
+import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { eq } from "drizzle-orm";
+import { Hash } from "viem";
+import { getConnection } from "./connection";
+import * as schema from "./schema";
+
+/**
+ * Proposal context registered for follow-up events
+ */
+export type Proposal = InferSelectModel<typeof schema.proposal>;
+/**
+ * Fields required to insert an proposal
+ */
+export type InsertableProposal = InferInsertModel<typeof schema.proposal>;
+
+/**
+ * Inserts a proposal. Does nothing if the proposal is already recorded.
+ *
+ * @param proposal - The proposal to insert
+ *
+ * @example
+ * await insertProposal(fields);
+ */
+export const insertProposal = async (proposal: InsertableProposal) => {
+  const { db } = getConnection();
+
+  await db.insert(schema.proposal).values(proposal).onConflictDoNothing();
+};
+
+/**
+ * Returns the active proposal for a given question id. If none exist, returns null.
+ *
+ * @param questionId - The question id
+ * @returns The active proposal or null
+ *
+ * @example
+ * const proposal = await findProposalByQuestionId(questionId);
+ */
+export const findProposalByQuestionId = async (questionId: Hash): Promise<Proposal | null> => {
+  const { db } = getConnection();
+
+  const results = await db.select().from(schema.proposal).where(eq(schema.proposal.questionId, questionId));
+
+  if (results.length === 0) return null;
+
+  return results[0];
+};
+
+/**
+ * Removes an active proposal by its question id.
+ *
+ * @param questionId - The question id
+ *
+ * @example
+ * await removeProposalByQuestionId(questionId);
+ */
+export const removeProposalByQuestionId = async (questionId: Hash) => {
+  const { db } = getConnection();
+
+  await db.delete(schema.proposal).where(eq(schema.proposal.questionId, questionId));
+};

--- a/src/services/db/schema.ts
+++ b/src/services/db/schema.ts
@@ -1,4 +1,4 @@
-import { bigint, pgEnum, pgTable, primaryKey, timestamp, unique, varchar } from "drizzle-orm/pg-core";
+import { bigint, index, pgEnum, pgTable, primaryKey, timestamp, varchar } from "drizzle-orm/pg-core";
 
 export const space = pgTable("space", {
   ens: varchar("ens").primaryKey(),
@@ -18,5 +18,23 @@ export const notification = pgTable(
   },
   (t) => ({
     pk: primaryKey({ columns: [t.txHash, t.transportName] }),
+  }),
+);
+
+export const proposal = pgTable(
+  "proposal",
+  {
+    proposalId: varchar("proposal_id", { length: 66 }).notNull().primaryKey(),
+    questionId: varchar("question_id", { length: 66 }).notNull(),
+    ens: varchar("ens")
+      .references(() => space.ens)
+      .notNull(),
+    txHash: varchar("tx_hash", { length: 66 }).notNull(),
+    happenedAt: timestamp("happened_at").notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (t) => ({
+    questionIdx: index("question_idx").on(t.questionId),
+    ensIdx: index("ens_idx").on(t.ens),
   }),
 );

--- a/src/services/reality/index.integration-test.ts
+++ b/src/services/reality/index.integration-test.ts
@@ -88,6 +88,7 @@ describe("Reality", () => {
         questionId: "0xebf5b601fedfaa5562a03590e9ac8be937cc070a131443af01948a7eda6dfabf",
         txHash: "0x890ddd7826fcd79ff17b54368e8df393959f269847ceeb0fea13cc4b68330d43",
         blockNumber: 19475120n,
+        happenedAt: new Date("2024-03-20T09:48:23.000Z"),
       });
     });
   });
@@ -111,9 +112,9 @@ describe("Reality", () => {
         answer: "0x0000000000000000000000000000000000000000000000000000000000000001",
         user: "0x4D6CAa3E0983fAc7B514D60339EBb538C5A85AAe",
         bond: 10000000n,
-        ts: 1712934227,
         txHash: "0x0cc20c32ee428bdb8f16fa1aa22b396ecafa91b61bc2c3350723e4dfefeebff0",
         blockNumber: 19640300n,
+        happenedAt: new Date("2024-04-12T15:03:47.000Z"),
       });
     });
   });

--- a/src/services/reality/index.ts
+++ b/src/services/reality/index.ts
@@ -128,12 +128,30 @@ export const configurableGetSpaceAddresses = async (
   return { moduleAddress, oracleAddress };
 };
 
+/**
+ * Given a block number, return the date it was mined
+ *
+ * @param blockNumber - The block number to get the date for
+ * @returns The date the block was mined
+ *
+ * @example
+ * const date = await getBlockDate(100n);
+ */
+const getBlockDate = async (blockNumber: bigint): Promise<Date> => {
+  const block = await getPublicClient().getBlock({ blockNumber });
+
+  // JS date accepts epoch as Number (not BigInt) of milliseconds
+  const epochInMs = Number(block.timestamp) * 1000;
+  return new Date(epochInMs);
+};
+
 export type ProposalQuestionCreated = {
-  proposalId: string;
-  questionId: string;
+  proposalId: Hash;
+  questionId: Hash;
 
   txHash: Hash;
   blockNumber: bigint;
+  happenedAt: Date;
 };
 type GetProposalQuestionsCreatedArgs = {
   realityModuleAddress: Address;
@@ -160,22 +178,27 @@ export const getProposalQuestionsCreated: GetProposalQuestionsCreatedFn = async 
     fromBlock,
     toBlock,
   });
-  const events: ProposalQuestionCreated[] = logs.map((log) => {
-    const decoded = decodeEventLog({
-      abi: realityModule.abi,
-      eventName: PROPOSAL_QUESTION_CREATED_EVENT_NAME,
-      data: log.data,
-      topics: log.topics,
-    });
+  const events: ProposalQuestionCreated[] = await Promise.all(
+    logs.map(async (log) => {
+      const decoded = decodeEventLog({
+        abi: realityModule.abi,
+        eventName: PROPOSAL_QUESTION_CREATED_EVENT_NAME,
+        data: log.data,
+        topics: log.topics,
+      });
 
-    return {
-      proposalId: decoded.args.proposalId,
-      questionId: decoded.args.questionId,
+      const happenedAt = await getBlockDate(log.blockNumber);
 
-      txHash: log.transactionHash,
-      blockNumber: log.blockNumber,
-    };
-  });
+      return {
+        proposalId: decoded.args.proposalId as Hash,
+        questionId: decoded.args.questionId as Hash,
+
+        txHash: log.transactionHash,
+        blockNumber: log.blockNumber,
+        happenedAt,
+      };
+    }),
+  );
   return events;
 };
 
@@ -184,10 +207,10 @@ export type LogNewAnswer = {
   answer: Hash;
   bond: bigint;
   user: Address;
-  ts: Number;
 
   blockNumber: bigint;
   txHash: Hash;
+  happenedAt: Date;
 };
 
 type GetLogNewAnswerArgs = {
@@ -224,14 +247,17 @@ export const getLogNewAnswer: GetLogNewAnswerFn = async (args) => {
       topics: log.topics,
     });
 
+    const epochInMs = Number(decoded.args.ts) * 1000;
+    const happenedAt = new Date(epochInMs);
+
     return {
       questionId: decoded.args.question_id,
       answer: decoded.args.answer,
       bond: decoded.args.bond,
       user: decoded.args.user,
-      ts: Number(decoded.args.ts),
       txHash: log.transactionHash,
       blockNumber: log.blockNumber,
+      happenedAt,
     };
   });
   return events;

--- a/src/utils/notification-template.test.ts
+++ b/src/utils/notification-template.test.ts
@@ -48,7 +48,9 @@ space.lastProcessedBlock: ${space.lastProcessedBlock}
 event.txHash: ${event.txHash}
 event.blockNumber: ${event.blockNumber}
 event.questionId: ${event.questionId}
-event.proposalId: ${event.proposalId}`;
+event.proposalId: ${event.proposalId}
+event.happenedAt: ${event.happenedAt.toISOString()}
+`;
       expect(result).to.equal(expectedResult.trim());
     });
 
@@ -73,7 +75,7 @@ event.questionId: ${event.questionId}
 event.answer: ${event.answer}
 event.bond: ${event.bond}
 event.user: ${event.user}
-event.ts: ${event.ts}
+event.happenedAt: ${event.happenedAt.toISOString()}
 `;
       expect(result).to.equal(expectedResult.trim());
     });

--- a/src/utils/test-mocks.ts
+++ b/src/utils/test-mocks.ts
@@ -6,11 +6,13 @@ import type { Space } from "../types";
 export const getRandomHex = (size: number): Hex =>
   (`0x` + [...Array(size)].map(() => Math.floor(Math.random() * 16).toString(16)).join(``)) as Hex;
 
-export const getRandomHash = (): Hash => getRandomHex(64);
+export const getRandomHash = (): Hash => getRandomHex(64) as Hash;
 export const getRandomAddress = (): Address => getRandomHex(40);
 
+export const randomizeEns = () => `test${Math.floor(Math.random() * 1000000)}.eth`;
+
 export const randomizeSpace = (): Space => ({
-  ens: "kleros.eth",
+  ens: randomizeEns(),
   startBlock: 100n,
   lastProcessedBlock: 50n,
   moduleAddress: getRandomAddress(),
@@ -22,6 +24,7 @@ export const randomizeProposalEventField = (): ProposalQuestionCreated => ({
   proposalId: getRandomHash(),
   questionId: getRandomHash(),
   blockNumber: 50n,
+  happenedAt: new Date(),
 });
 
 export const randomizeAnswerEventField = (): LogNewAnswer => ({
@@ -29,18 +32,21 @@ export const randomizeAnswerEventField = (): LogNewAnswer => ({
   answer: "0x0000000000000000000000000000000000000000000000000000000000000001",
   bond: 100000000000000000n,
   user: getRandomAddress(),
-  ts: 1710928271,
   txHash: getRandomHash(),
   blockNumber: 50n,
+  happenedAt: new Date(),
 });
 
 /**
  * Generates a Proposal notification with randomized values
+ *
+ * @param fields - Fields that has a fixed value and should not be randomized
  */
-export const randomizeProposalNotification = (): ProposalNotification => ({
+export const randomizeProposalNotification = (fields?: Partial<ProposalNotification>): ProposalNotification => ({
   type: EventType.PROPOSAL_QUESTION_CREATED,
   space: randomizeSpace(),
   event: randomizeProposalEventField(),
+  ...fields,
 });
 
 /**

--- a/templates/test/answer-issued.ejs
+++ b/templates/test/answer-issued.ejs
@@ -10,4 +10,4 @@ event.questionId: <%- notification.event.questionId %>
 event.answer: <%- notification.event.answer %>
 event.bond: <%- notification.event.bond %>
 event.user: <%- notification.event.user %>
-event.ts: <%- notification.event.ts %>
+event.happenedAt: <%- notification.event.happenedAt.toISOString() %>

--- a/templates/test/proposal-created.ejs
+++ b/templates/test/proposal-created.ejs
@@ -8,3 +8,4 @@ event.txHash: <%- notification.event.txHash %>
 event.blockNumber: <%- notification.event.blockNumber %>
 event.questionId: <%- notification.event.questionId %>
 event.proposalId: <%- notification.event.proposalId %>
+event.happenedAt: <%- notification.event.happenedAt.toISOString() %>


### PR DESCRIPTION
Previous implentation worked under the asumption that the oracle contract was
unique per space, but it is not. To identify if a answer event is related to
a subscribed space, the application needs to keep track of the existing
proposals and their `questionId`.

This commit includes the following changes:
- Code for processing proposals and answers is extracted into their own
functions.
- Once a proposal for a subscribed space is detected, it is recorded in the db.
- As the proposal (more specifically, the `questionId`) is required to correctly
identify an answer, proposals and answers are no longer processed concurrently
but sequentially.
- A `happenedAt` field has been included in both proposals and answers. This
will allow ignoring stale events and recorded proposals.
- Adjusted tests to make use of the random generators.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a `proposal` table to manage proposal details, enhancing data organization.
	- Added functionality to handle proposals and answers with dedicated processing functions.
	- Implemented a `getBlockDate` function to retrieve block mining dates, improving event context.
	- Expanded tests for processing proposals and answers, validating correct notifications and data integrity.
	- Enhanced the modularity and clarity of the processing logic for proposals and answers.

- **Bug Fixes**
	- Improved timestamp handling in notifications and tests for consistency and clarity.

- **Tests**
	- Expanded integration tests for proposal management, ensuring reliability of insert, find, and delete operations.
	- Introduced new test suites for processing proposals and answers, enhancing robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->