### PR TITLE
fix(shutdown): fixes start errors not triggering graceful shutdown

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -70,18 +70,19 @@ export const configurableStart = async (deps: ConfigurableStartDeps) => {
 
   initializeLoggerFn(emitter);
   initializeGracefulShutdownFn();
-  emitter.emit(BotEventNames.STARTED);
-  initializeSlackFn();
-  initializeTelegramFn();
-  initializeEmailFn();
-  initializeHeartbeatFn();
-
-  let spaces = await initializeSpacesFn(parsedSpaces);
-
-  const shutdownSignalPromise = resolveOnEvent(BotEventNames.GRACEFUL_SHUTDOWN_START, emitter);
-  let shouldContinue = await isPromisePending(shutdownSignalPromise);
 
   try {
+    emitter.emit(BotEventNames.STARTED);
+    initializeSlackFn();
+    initializeTelegramFn();
+    initializeEmailFn();
+    initializeHeartbeatFn();
+
+    let spaces = await initializeSpacesFn(parsedSpaces);
+
+    const shutdownSignalPromise = resolveOnEvent(BotEventNames.GRACEFUL_SHUTDOWN_START, emitter);
+    let shouldContinue = await isPromisePending(shutdownSignalPromise);
+
     while (shouldContinue) {
       emitter.emit(BotEventNames.ITERATION_STARTED);
       spaces = await processSpacesFn(spaces);


### PR DESCRIPTION
Graceful shutdown is correctly handled for errors during processing step,
but errors happening during the start sequence was not triggering it.

This results in the bot never shutting down while keeping the main loop
active with heartbeats.

This commit includes the start sequence inside the block of code that
triggers the shutdown on exception.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
	- Enhanced error handling during the bot's initialization process, improving resilience and reliability.
	- Restructured control flow to better manage potential failures during startup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->