### PR TITLE
test(spaces): fixes assertions failing due to operator

### DIFF
--- a/src/services/db/spaces.integration-test.ts
+++ b/src/services/db/spaces.integration-test.ts
@@ -23,7 +23,7 @@ describe("Space model", () => {
 
       const enss = fakeSpaces.map((space) => space.ens);
       const result = await fn(enss);
-      expect(result).to.deep.eq(fakeSpaces);
+      expect(result).to.deep.equal(fakeSpaces);
     });
 
     it("should return empty array if no spaces are found", async () => {
@@ -51,7 +51,7 @@ describe("Space model", () => {
           ),
         );
 
-      expect(inserted).to.deep.eq(fakeSpaces);
+      expect(inserted).to.deep.equal(fakeSpaces);
     });
   });
 });


### PR DESCRIPTION
The use of `.eql` instead of `.equal` was causing two test to report failures


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Standardized assertion syntax within integration tests to ensure consistent validation of space-related data operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->