### PR TITLE
Adds support for multiple SafeSnap plugins key JSON schemas and ENS subdomains

### DIFF
--- a/src/services/reality/index.integration-test.ts
+++ b/src/services/reality/index.integration-test.ts
@@ -12,9 +12,14 @@ import {
 describe("Reality", () => {
   const fn = getRealityModuleAddress;
   describe("getRealityModuleAddress", () => {
-    it("should return the address of the reality module contract", async () => {
+    it("should return the address of the reality module contract (old JSON plugins format)", async () => {
       const address = await fn("1inch.eth");
       expect(address).to.equal(ONEINCH_MODULE_ADDRESS);
+    });
+
+    it("should return the address of the reality module contract (new JSON plugins format)", async () => {
+      const address = await fn("testsnapshotspace.eth");
+      expect(address).to.equal("0x27bC6f27581CA89809213eDd7dD1ff7b55E65F8C");
     });
 
     it("should return null when the address is not found", async () => {

--- a/src/services/reality/index.ts
+++ b/src/services/reality/index.ts
@@ -23,17 +23,29 @@ if (!PROPOSAL_QUESTION_CREATED_ABI || !LOG_NEW_QUESTION_ABI || !LOG_NEW_ANSWER_A
   throw new Error(`Unable to find events in ABI`);
 }
 
+type AddressPluginStructure = {
+  address: Address;
+};
+
+type SafePluginStructure = {
+  safes: Array<{
+    network: String;
+    realityAddress: Address;
+  }>;
+};
+
 type QueryResponse = {
   space: {
     plugins: {
-      safeSnap: {
-        address: Address;
-      };
+      safeSnap: AddressPluginStructure | SafePluginStructure;
     };
   };
 };
 /**
  * Get the address of the Reality Module contract for a given space
+ *
+ * This function supports both the deprecated plugins field format (`address` key directly present)
+ * and the new one (`safes` array with the value in the `realityAddress` key)
  *
  * @param spaceId - The ID of the space to get the contract address for
  * @returns The address of the contract
@@ -42,8 +54,8 @@ type QueryResponse = {
  *
  * const address = await getRealityModuleAddress("1inch.eth");
  */
-type GetRealityModuleAddressFn = (spaceId: string) => Promise<Address | null>;
-export const getRealityModuleAddress: GetRealityModuleAddressFn = async (spaceId) => {
+type GetRealityModuleAddressFn = (spaceId: string, chainId?: number) => Promise<Address | null>;
+export const getRealityModuleAddress: GetRealityModuleAddressFn = async (spaceId, chainId = env.CHAIN_ID) => {
   const query = `
     query {
       space(id: "${spaceId}") {
@@ -53,7 +65,18 @@ export const getRealityModuleAddress: GetRealityModuleAddressFn = async (spaceId
   `;
   const { space } = await graphQLFetch<QueryResponse>(env.SNAPSHOT_GRAPHQL_URL, query);
 
-  return space ? space.plugins.safeSnap.address : null;
+  const safeSnap = space?.plugins?.safeSnap;
+
+  if (!safeSnap) return null;
+
+  if ("address" in safeSnap) return safeSnap.address;
+
+  if ("safes" in safeSnap) {
+    const safe = safeSnap.safes.find((safe) => safe.network == String(chainId));
+    return safe ? safe.realityAddress : null;
+  }
+
+  return null;
 };
 
 type GetRealityOracleAddressFn = (realityModuleAddress: Address) => Promise<Address | null>;

--- a/src/utils/env.test.ts
+++ b/src/utils/env.test.ts
@@ -10,6 +10,13 @@ describe("Environment variables lib", () => {
       expect(fn(input)).to.equal(input);
     });
 
+    it("should allow a subdomains in space", () => {
+      let input = "governance.kleros.eth:1000000";
+      expect(fn(input)).to.equal(input);
+      input = "also.valid.governance.kleros.eth:100000";
+      expect(fn(input)).to.equal(input);
+    });
+
     it("should allow multiple comma separated spaces", () => {
       const input = "kleros.eth:1000000,kleros2.eth:2000000";
       expect(fn(input)).to.equal(input);

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -17,6 +17,7 @@ import { Address } from "viem";
  * @example
  *
  * validateSpaces("kleros.eth:3000000"); // valid
+ * validateSpaces("governance.kleros.eth:3000000"); // valid
  * validateSpaces("kleros.eth:3000000,1inch.eth:6000000"); // valid
  * validateSpaces(""); // invalid
  * validateSpaces("kleros.eth"); // invalid
@@ -26,7 +27,15 @@ import { Address } from "viem";
  * validateSpaces("kleros.eth:1000,1inch.eth:2000:0x1234567890abcdef1234567890abcdef12345678"); // valid
  */
 export const validateSpaces = (input: string) => {
-  const isValid = /^[\w-]+\.eth:\d+(:0x[a-fA-F0-9]{40})?(,[\w-]+\.eth:\d+(:0x[a-fA-F0-9]{40})?)*$/.test(input);
+  const ens = "(?:[\\w-]+\\.)+eth";
+
+  // ens:blockNumber:realityModuleAddress
+  const entry = `${ens}:\\d+(?::0x[a-fA-F0-9]{40})?`;
+
+  // Comma separated list of space entries
+  const entriesRegex = new RegExp(`^${entry}(?:,${entry})*$`);
+
+  const isValid = entriesRegex.test(input);
 
   if (!isValid) throw new Error("Invalid spaces format");
 


### PR DESCRIPTION
This PR addresses two issues:

1. SafeSnap plugin uses different JSON schemas for legacy and modern spaces configuration. The function to resolve the Reality Module address using the Snapshot GraphQL API is now aware of both schemas.
2. The previous environment variables validation rejected ENS with subdomains. Now we can use subdomains in spaces


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced support for multiple plugin data formats to improve compatibility with legacy and new JSON plugin configurations.
  * Added support for ENS subdomains in space validation (e.g., governance.kleros.eth).
  * Improved multi-chain functionality with chain ID parameter support.

* **Tests**
  * Expanded test coverage for new plugin formats and ENS subdomain validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->