### PR TITLE
chore(links): normalizes reality links to use their casing

### DIFF
--- a/src/utils/links.test.ts
+++ b/src/utils/links.test.ts
@@ -27,7 +27,7 @@ describe("getRealityQuestionLink", () => {
     } as any as ValidProposalNotification;
     const template = "http://test.com/{{oracleAddress}}/questions/{{questionId}}";
     const result = getRealityQuestionLink(notification, template);
-    expect(result).to.eql(`http://test.com/${oracleAddress}/questions/${questionId}`);
+    expect(result).to.eql(`http://test.com/${oracleAddress.toLowerCase()}/questions/${questionId.toLowerCase()}`);
   });
 });
 

--- a/src/utils/links.ts
+++ b/src/utils/links.ts
@@ -52,7 +52,10 @@ export const getRealityQuestionLink = (
     space: { oracleAddress },
     event: { questionId },
   } = notification;
-  return interpolateUrlTemplate(template, { oracleAddress, questionId });
+  return interpolateUrlTemplate(template, {
+    oracleAddress: oracleAddress.toLowerCase(),
+    questionId: questionId.toLowerCase(),
+  });
 };
 
 /**


### PR DESCRIPTION
Reality links that were previously working are now showing "Forbidden" errors. After checking for differences between
the native links and the bots one I noticed a case difference. Now the links looks equal, but the issue is persisting.
I am still promoting the changes to PR as having similar shaped links is better.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed URL construction for Reality question links to use lowercase oracle addresses and question IDs for consistent link formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->