### PR TITLE
fix: handles the case of a reality question with no snapshot proposal

### DIFF
--- a/src/processing.ts
+++ b/src/processing.ts
@@ -21,7 +21,7 @@ import { getProposal } from "./services/snapshot";
 import type { Space } from "./types";
 import { defaultEmitter } from "./utils/emitter";
 import { env } from "./utils/env";
-import { MissingLogNewQuestionEventError, MissingSnapshotProposalError } from "./utils/errors";
+import { MissingLogNewQuestionEventError } from "./utils/errors";
 import { validateRealityQuestion, ValidationResult } from "./utils/reality-question-validation";
 import { ValidationErrorSeverity } from "./utils/reality-question-validation/errors";
 
@@ -280,7 +280,6 @@ export const configurableProcessProposals = async (deps: ConfigurableProcessProp
       const { question, startedAt, finishedAt, timeout } = newQuestionEvent;
 
       const proposal = await getSnapshotProposalFn(question.proposalId);
-      if (!proposal) throw new MissingSnapshotProposalError(event.proposalId, event.questionId, event.txHash);
 
       const validation = validateRealityQuestionFn(newQuestionEvent, proposal);
 

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -8,12 +8,3 @@ export class MissingLogNewQuestionEventError extends Error {
     Error.captureStackTrace(this, MissingLogNewQuestionEventError);
   }
 }
-
-export class MissingSnapshotProposalError extends Error {
-  constructor(proposalId: Hex, questionId: Hex, txHash: Hash) {
-    const message = `Unable to resolve proposal ${proposalId} related to Reality question ${questionId} present in the LogNewQuestion event in tx ${txHash}`;
-    super(message);
-    this.name = this.constructor.name;
-    Error.captureStackTrace(this, MissingSnapshotProposalError);
-  }
-}

--- a/src/utils/reality-question-validation/errors.ts
+++ b/src/utils/reality-question-validation/errors.ts
@@ -1,4 +1,4 @@
-import { Hash } from "viem";
+import { Hash, Hex } from "viem";
 
 export enum ValidationErrorSeverity {
   SECURITY_ALERT = "security-alert",
@@ -17,6 +17,15 @@ export class BaseProposalValidationError extends Error {
   constructor(severity: ValidationErrorSeverity, message: string) {
     super(message);
     this.severity = severity;
+  }
+}
+
+export class MissingSnapshotProposalError extends BaseProposalValidationError {
+  constructor(proposalId: Hex) {
+    super(
+      ValidationErrorSeverity.INCOMPLETE_DATA,
+      `The Snapshot GraphQL API didn't return any proposal with proposalId ${proposalId}`,
+    );
   }
 }
 

--- a/src/utils/reality-question-validation/index.test.ts
+++ b/src/utils/reality-question-validation/index.test.ts
@@ -4,6 +4,7 @@ import { LogNewQuestion } from "../../services/reality";
 import { assertValidRealityQuestion } from ".";
 import { expect } from "chai";
 import {
+  MissingSnapshotProposalError,
   ProposalIdMismatchError,
   SafeHashCalculationError,
   SafeHashMismatchError,
@@ -102,6 +103,10 @@ describe("Reality/Proposal Validation", () => {
     });
 
     describe("it should warn when it is missing data to perform the validation", () => {
+      it("because there is not proposal", () => {
+        expect(() => fn(event, null)).to.throw(MissingSnapshotProposalError);
+      });
+
       it("because the snapshot plugin data is missing", () => {
         // @ts-ignore Force test condition
         proposal.plugins.safeSnap = null;

--- a/src/utils/reality-question-validation/index.ts
+++ b/src/utils/reality-question-validation/index.ts
@@ -4,6 +4,7 @@ import { SnapshotProposal } from "../../services/snapshot";
 import { calculateTxHash } from "./eip-712-transaction-hash";
 import {
   BaseProposalValidationError,
+  MissingSnapshotProposalError,
   ProposalIdMismatchError,
   SafeHashCalculationError,
   SafeHashMismatchError,
@@ -27,10 +28,13 @@ import {
  * // it will just execute without returning anything
  * assertValidRealityQuestion(event, proposal);
  */
-export const assertValidRealityQuestion = (event: LogNewQuestion, proposal: SnapshotProposal) => {
+export const assertValidRealityQuestion = (event: LogNewQuestion, proposal: SnapshotProposal | null) => {
+  if (!proposal) throw new MissingSnapshotProposalError(event.question.proposalId);
+
   if (proposal.id != event.question.proposalId) {
     throw new ProposalIdMismatchError(proposal.id, event.question.proposalId);
   }
+
   const safes = proposal.plugins?.safeSnap?.safes;
   if (!safes || safes.length < 1) {
     throw new SafeSnapPluginConfigurationError();
@@ -96,7 +100,7 @@ export type ValidationResult = ValidationResultOK | ValidationResultFailed;
  * const result = validateRealityQuestion(event, proposal);
  * if (result.isValid) console.log("Validation passed!");
  */
-export const validateRealityQuestion = (event: LogNewQuestion, proposal: SnapshotProposal): ValidationResult => {
+export const validateRealityQuestion = (event: LogNewQuestion, proposal: SnapshotProposal | null): ValidationResult => {
   try {
     assertValidRealityQuestion(event, proposal);
     return { isValid: true };


### PR DESCRIPTION
The recent 1inch event provided a specimen of an unexpected case: a Reality question for a proposal
that does not exists. This PR improves the keccak validation flow so the situation is handled gracefully
