### PR TITLE
Prevents a malformed proposal from crashing the bot

### DIFF
--- a/src/services/snapshot/index.ts
+++ b/src/services/snapshot/index.ts
@@ -68,7 +68,7 @@ type ProposalSafeBatchTransactionResponse = {
   abi?: Array<string>;
 };
 
-type ProposalSafeBatchResponse = {
+export type ProposalSafeBatchResponse = {
   hash: Hash;
   nonce: number;
   transactions: Array<ProposalSafeBatchTransactionResponse>;

--- a/src/utils/reality-question-validation/errors.ts
+++ b/src/utils/reality-question-validation/errors.ts
@@ -46,6 +46,24 @@ export class SafeSnapPluginConfigurationError extends BaseProposalValidationErro
   }
 }
 
+export class MalformedSafeSnapTxError extends BaseProposalValidationError {
+  constructor(index: number) {
+    super(
+      ValidationErrorSeverity.INCOMPLETE_DATA,
+      `The SafeSnap plugin transaction at index ${index} is missing its mainTransaction or required fields (to, data, nonce, value, operation)`,
+    );
+  }
+}
+
+export class MalformedSafeError extends BaseProposalValidationError {
+  constructor(index: number) {
+    super(
+      ValidationErrorSeverity.INCOMPLETE_DATA,
+      `The SafeSnap safe at index ${index} is malformed (invalid or missing network, realityAddress, or transactions)`,
+    );
+  }
+}
+
 export class TxHashMismatchError extends BaseProposalValidationError {
   constructor(snapshotHash: Hash, computedHash: Hash) {
     super(

--- a/src/utils/reality-question-validation/index.test.ts
+++ b/src/utils/reality-question-validation/index.test.ts
@@ -117,7 +117,7 @@ describe("Reality/Proposal Validation", () => {
       });
 
       it("because the snapshot plugin data is missing", () => {
-        // @ts-ignore Force test condition
+        // @ts-expect-error Force test condition
         proposal.plugins.safeSnap = null;
         expect(() => fn(event, proposal)).to.throw(SafeSnapPluginConfigurationError);
       });
@@ -138,19 +138,19 @@ describe("Reality/Proposal Validation", () => {
       });
 
       it("because a safeSnap tx entry is null", () => {
-        // @ts-ignore Force test condition
+        // @ts-expect-error Force test condition
         proposal.plugins.safeSnap.safes[0].txs[0] = null;
         expect(() => fn(event, proposal)).to.throw(MalformedSafeSnapTxError);
       });
 
       it("because a safeSnap tx is missing its mainTransaction", () => {
-        // @ts-ignore Force test condition
+        // @ts-expect-error Force test condition
         proposal.plugins.safeSnap.safes[0].txs[0].mainTransaction = undefined;
         expect(() => fn(event, proposal)).to.throw(MalformedSafeSnapTxError);
       });
 
       it("because a safeSnap tx mainTransaction is missing a required field", () => {
-        // @ts-ignore Force test condition
+        // @ts-expect-error Force test condition
         proposal.plugins.safeSnap.safes[0].txs[0].mainTransaction.to = undefined;
         expect(() => fn(event, proposal)).to.throw(MalformedSafeSnapTxError);
       });
@@ -161,7 +161,7 @@ describe("Reality/Proposal Validation", () => {
       });
 
       it("because a safeSnap tx carries a non-integer number instead of a numeric string", () => {
-        // @ts-ignore Force test condition: the author-controlled JSON can hold a raw number
+        // @ts-expect-error Force test condition: the author-controlled JSON can hold a raw number
         proposal.plugins.safeSnap.safes[0].txs[0].mainTransaction.value = 1.5;
         expect(() => fn(event, proposal)).to.throw(MalformedSafeSnapTxError);
       });
@@ -187,13 +187,13 @@ describe("Reality/Proposal Validation", () => {
       });
 
       it("because a safeSnap tx has a non-numeric operation", () => {
-        // @ts-ignore Force test condition
+        // @ts-expect-error Force test condition
         proposal.plugins.safeSnap.safes[0].txs[0].mainTransaction.operation = "banana";
         expect(() => fn(event, proposal)).to.throw(MalformedSafeSnapTxError);
       });
 
       it("because a safeSnap tx has an operation outside the Safe range", () => {
-        // @ts-ignore Force test condition
+        // @ts-expect-error Force test condition
         proposal.plugins.safeSnap.safes[0].txs[0].mainTransaction.operation = "2";
         expect(() => fn(event, proposal)).to.throw(MalformedSafeSnapTxError);
       });
@@ -204,7 +204,7 @@ describe("Reality/Proposal Validation", () => {
       });
 
       it("because a safeSnap tx nonce exceeds the uint256 range", () => {
-        // @ts-ignore Force test condition: the author-controlled JSON can hold an out-of-range nonce
+        // @ts-expect-error Force test condition: the author-controlled JSON can hold an out-of-range nonce
         proposal.plugins.safeSnap.safes[0].txs[0].mainTransaction.nonce = (2n ** 256n).toString();
         expect(() => fn(event, proposal)).to.throw(MalformedSafeSnapTxError);
       });
@@ -220,13 +220,13 @@ describe("Reality/Proposal Validation", () => {
       });
 
       it("because a safe has no transactions array", () => {
-        // @ts-ignore Force test condition
+        // @ts-expect-error Force test condition
         proposal.plugins.safeSnap.safes[0].txs = undefined;
         expect(() => fn(event, proposal)).to.throw(MalformedSafeError);
       });
 
       it("because a safe entry is null", () => {
-        // @ts-ignore Force test condition
+        // @ts-expect-error Force test condition
         proposal.plugins.safeSnap.safes[0] = null;
         expect(() => fn(event, proposal)).to.throw(MalformedSafeError);
       });

--- a/src/utils/reality-question-validation/index.test.ts
+++ b/src/utils/reality-question-validation/index.test.ts
@@ -87,6 +87,13 @@ describe("Reality/Proposal Validation", () => {
       expect(() => fn(event, proposal)).not.to.throw();
     });
 
+    it("should finish without errors when the addresses are valid but not checksummed", () => {
+      const safe = proposal.plugins.safeSnap.safes[0];
+      safe.txs[0].mainTransaction.to = safe.txs[0].mainTransaction.to.toLowerCase() as Address;
+      safe.realityAddress = safe.realityAddress.toLowerCase() as Address;
+      expect(() => fn(event, proposal)).not.to.throw();
+    });
+
     describe("it should raise a security alert", () => {
       it("when a tx hash can not be recreated", () => {
         proposal.plugins.safeSnap.safes[0].txs[0].mainTransaction.value = "4242";

--- a/src/utils/reality-question-validation/index.test.ts
+++ b/src/utils/reality-question-validation/index.test.ts
@@ -4,6 +4,8 @@ import { LogNewQuestion } from "../../services/reality";
 import { assertValidRealityQuestion } from ".";
 import { expect } from "chai";
 import {
+  MalformedSafeError,
+  MalformedSafeSnapTxError,
   MissingSnapshotProposalError,
   ProposalIdMismatchError,
   SafeHashCalculationError,
@@ -126,6 +128,94 @@ describe("Reality/Proposal Validation", () => {
       it("because no safe exists for the proposal network", () => {
         proposal.network = "50000";
         expect(() => fn(event, proposal)).to.throw(SafeNotFoundForProposalNetworkError);
+      });
+
+      it("because a safeSnap tx is missing its mainTransaction", () => {
+        // @ts-ignore Force test condition
+        proposal.plugins.safeSnap.safes[0].txs[0].mainTransaction = undefined;
+        expect(() => fn(event, proposal)).to.throw(MalformedSafeSnapTxError);
+      });
+
+      it("because a safeSnap tx mainTransaction is missing a required field", () => {
+        // @ts-ignore Force test condition
+        proposal.plugins.safeSnap.safes[0].txs[0].mainTransaction.to = undefined;
+        expect(() => fn(event, proposal)).to.throw(MalformedSafeSnapTxError);
+      });
+
+      it("because a safeSnap tx has an unparseable numeric field", () => {
+        proposal.plugins.safeSnap.safes[0].txs[0].mainTransaction.value = "not-a-number";
+        expect(() => fn(event, proposal)).to.throw(MalformedSafeSnapTxError);
+      });
+
+      it("because a safeSnap tx carries a non-integer number instead of a numeric string", () => {
+        // @ts-ignore Force test condition: the author-controlled JSON can hold a raw number
+        proposal.plugins.safeSnap.safes[0].txs[0].mainTransaction.value = 1.5;
+        expect(() => fn(event, proposal)).to.throw(MalformedSafeSnapTxError);
+      });
+
+      it("because a safeSnap tx has a recipient that is not an address", () => {
+        proposal.plugins.safeSnap.safes[0].txs[0].mainTransaction.to = "not-an-address" as Address;
+        expect(() => fn(event, proposal)).to.throw(MalformedSafeSnapTxError);
+      });
+
+      it("because a safeSnap tx has call data that is not hex", () => {
+        proposal.plugins.safeSnap.safes[0].txs[0].mainTransaction.data = "not-hex";
+        expect(() => fn(event, proposal)).to.throw(MalformedSafeSnapTxError);
+      });
+
+      it("because a safeSnap tx has a negative value", () => {
+        proposal.plugins.safeSnap.safes[0].txs[0].mainTransaction.value = "-1";
+        expect(() => fn(event, proposal)).to.throw(MalformedSafeSnapTxError);
+      });
+
+      it("because a safeSnap tx has a negative nonce", () => {
+        proposal.plugins.safeSnap.safes[0].txs[0].mainTransaction.nonce = -1;
+        expect(() => fn(event, proposal)).to.throw(MalformedSafeSnapTxError);
+      });
+
+      it("because a safeSnap tx has a non-numeric operation", () => {
+        // @ts-ignore Force test condition
+        proposal.plugins.safeSnap.safes[0].txs[0].mainTransaction.operation = "banana";
+        expect(() => fn(event, proposal)).to.throw(MalformedSafeSnapTxError);
+      });
+
+      it("because a safeSnap tx has an operation outside the Safe range", () => {
+        // @ts-ignore Force test condition
+        proposal.plugins.safeSnap.safes[0].txs[0].mainTransaction.operation = "2";
+        expect(() => fn(event, proposal)).to.throw(MalformedSafeSnapTxError);
+      });
+
+      it("because a safeSnap tx value exceeds the uint256 range", () => {
+        proposal.plugins.safeSnap.safes[0].txs[0].mainTransaction.value = (2n ** 256n).toString();
+        expect(() => fn(event, proposal)).to.throw(MalformedSafeSnapTxError);
+      });
+
+      it("because a safeSnap tx nonce exceeds the uint256 range", () => {
+        // @ts-ignore Force test condition: the author-controlled JSON can hold an out-of-range nonce
+        proposal.plugins.safeSnap.safes[0].txs[0].mainTransaction.nonce = (2n ** 256n).toString();
+        expect(() => fn(event, proposal)).to.throw(MalformedSafeSnapTxError);
+      });
+
+      it("because a safe has a realityAddress that is not an address", () => {
+        proposal.plugins.safeSnap.safes[0].realityAddress = "not-an-address" as Address;
+        expect(() => fn(event, proposal)).to.throw(MalformedSafeError);
+      });
+
+      it("because a safe has a non-numeric network", () => {
+        proposal.plugins.safeSnap.safes[0].network = "not-a-number";
+        expect(() => fn(event, proposal)).to.throw(MalformedSafeError);
+      });
+
+      it("because a safe has no transactions array", () => {
+        // @ts-ignore Force test condition
+        proposal.plugins.safeSnap.safes[0].txs = undefined;
+        expect(() => fn(event, proposal)).to.throw(MalformedSafeError);
+      });
+
+      it("because a safe entry is null", () => {
+        // @ts-ignore Force test condition
+        proposal.plugins.safeSnap.safes[0] = null;
+        expect(() => fn(event, proposal)).to.throw(MalformedSafeError);
       });
     });
   });

--- a/src/utils/reality-question-validation/index.test.ts
+++ b/src/utils/reality-question-validation/index.test.ts
@@ -137,6 +137,12 @@ describe("Reality/Proposal Validation", () => {
         expect(() => fn(event, proposal)).to.throw(SafeNotFoundForProposalNetworkError);
       });
 
+      it("because a safeSnap tx entry is null", () => {
+        // @ts-ignore Force test condition
+        proposal.plugins.safeSnap.safes[0].txs[0] = null;
+        expect(() => fn(event, proposal)).to.throw(MalformedSafeSnapTxError);
+      });
+
       it("because a safeSnap tx is missing its mainTransaction", () => {
         // @ts-ignore Force test condition
         proposal.plugins.safeSnap.safes[0].txs[0].mainTransaction = undefined;

--- a/src/utils/reality-question-validation/index.ts
+++ b/src/utils/reality-question-validation/index.ts
@@ -21,7 +21,9 @@ import {
  * transaction data as always present, but the response can omit it or hold unparseable values, so
  * anything malformed becomes a validation error instead of an uncaught exception that crashes the bot.
  *
- * @param tx - The safeSnap transaction to read.
+ * @param tx - The safeSnap transaction to read. The declared type is non-null, but the value comes
+ *   from the author-controlled Snapshot plugins JSON (cast, never validated), so a malformed payload
+ *   can hold a null entry here.
  * @param index - The position of the transaction in the safe, used in the error message.
  * @returns The parsed message, ready for the EIP-712 hash calculation.
  * @throws {MalformedSafeSnapTxError} When the transaction data is missing or cannot be parsed.
@@ -29,7 +31,7 @@ import {
  * @example
  * const message = parseSafeSnapTxMessage(tx, 0);
  */
-const parseSafeSnapTxMessage = (tx: ProposalSafeBatchResponse, index: number) => {
+const parseSafeSnapTxMessage = (tx: ProposalSafeBatchResponse | null, index: number) => {
   const mainTransaction = tx?.mainTransaction;
   if (!mainTransaction) throw new MalformedSafeSnapTxError(index);
 

--- a/src/utils/reality-question-validation/index.ts
+++ b/src/utils/reality-question-validation/index.ts
@@ -1,9 +1,11 @@
-import { Address, concat, Hex, keccak256 } from "viem";
+import { concat, isAddress, isHex, keccak256, maxUint256 } from "viem";
 import { LogNewQuestion } from "../../services/reality";
-import { SnapshotProposal } from "../../services/snapshot";
+import { ProposalSafeBatchResponse, SnapshotProposal } from "../../services/snapshot";
 import { calculateTxHash } from "./eip-712-transaction-hash";
 import {
   BaseProposalValidationError,
+  MalformedSafeError,
+  MalformedSafeSnapTxError,
   MissingSnapshotProposalError,
   ProposalIdMismatchError,
   SafeHashCalculationError,
@@ -13,6 +15,57 @@ import {
   TxHashMismatchError,
   ValidationErrorSeverity,
 } from "./errors";
+
+/**
+ * Reads and parses the EIP-712 message from a safeSnap transaction. The Snapshot API types mark the
+ * transaction data as always present, but the response can omit it or hold unparseable values, so
+ * anything malformed becomes a validation error instead of an uncaught exception that crashes the bot.
+ *
+ * @param tx - The safeSnap transaction to read.
+ * @param index - The position of the transaction in the safe, used in the error message.
+ * @returns The parsed message, ready for the EIP-712 hash calculation.
+ * @throws {MalformedSafeSnapTxError} When the transaction data is missing or cannot be parsed.
+ *
+ * @example
+ * const message = parseSafeSnapTxMessage(tx, 0);
+ */
+const parseSafeSnapTxMessage = (tx: ProposalSafeBatchResponse, index: number) => {
+  const mainTransaction = tx?.mainTransaction;
+  if (!mainTransaction) throw new MalformedSafeSnapTxError(index);
+
+  const { to, data, nonce, value, operation } = mainTransaction;
+  if ([to, data, nonce, value, operation].some((field) => field == null)) {
+    throw new MalformedSafeSnapTxError(index);
+  }
+
+  // The Snapshot plugin JSON is author-controlled and not schema-validated upstream, so a well-typed
+  // hash computation is not guaranteed. Validate every field the EIP-712 encoder is strict about
+  // (address, hex data, uint256-range value/nonce, Safe operation) so a malformed payload becomes a
+  // validation error instead of an uncaught throw inside calculateTxHash.
+  if (!isAddress(to) || !isHex(data)) throw new MalformedSafeSnapTxError(index);
+
+  const operationNumber = Number(operation);
+  if (operationNumber !== 0 && operationNumber !== 1) throw new MalformedSafeSnapTxError(index);
+
+  let nonceValue: bigint;
+  let txValue: bigint;
+  try {
+    nonceValue = BigInt(nonce);
+    txValue = BigInt(value);
+  } catch (error) {
+    // BigInt() raises SyntaxError on an unparseable string and RangeError on a non-integer number.
+    if (error instanceof SyntaxError || error instanceof RangeError) {
+      throw new MalformedSafeSnapTxError(index);
+    }
+    throw error;
+  }
+  // BigInt is arbitrary precision, so it accepts values the uint256 encoder rejects; bound both ends.
+  if (nonceValue < 0n || nonceValue > maxUint256 || txValue < 0n || txValue > maxUint256) {
+    throw new MalformedSafeSnapTxError(index);
+  }
+
+  return { to, data, nonce: nonceValue, value: txValue, operation: operationNumber };
+};
 
 /**
  * Validate the provided question against the proposal, throwing an error
@@ -40,29 +93,29 @@ export const assertValidRealityQuestion = (event: LogNewQuestion, proposal: Snap
     throw new SafeSnapPluginConfigurationError();
   }
 
-  safes.forEach((safe) => {
+  safes.forEach((safe, safeIndex) => {
+    // The safe fields come from the same author-controlled plugin JSON as the transactions, so a
+    // malformed realityAddress, network, or txs must not reach the encoder as an uncaught throw.
+    if (!safe || !Array.isArray(safe.txs)) throw new MalformedSafeError(safeIndex);
+
     const { network, realityAddress, txs, hash } = safe;
 
+    if (!isAddress(realityAddress)) throw new MalformedSafeError(safeIndex);
+
+    const chainId = Number(network);
+    if (!Number.isInteger(chainId) || chainId < 0) throw new MalformedSafeError(safeIndex);
+
     const domain = {
-      chainId: Number(network),
-      verifyingContract: realityAddress as Address,
+      chainId,
+      verifyingContract: realityAddress,
     } as const;
 
-    const txHashes = txs.map((tx) => {
-      const {
-        hash,
-        mainTransaction: { to, data, nonce, value, operation },
-      } = tx;
+    const txHashes = txs.map((tx, index) => {
+      const message = parseSafeSnapTxMessage(tx, index);
 
-      const calculatedHash = calculateTxHash(domain, {
-        to: to as Address,
-        data: data as Hex,
-        nonce: BigInt(nonce),
-        value: BigInt(value),
-        operation: Number(operation),
-      });
+      const calculatedHash = calculateTxHash(domain, message);
 
-      if (hash != calculatedHash) throw new TxHashMismatchError(hash, calculatedHash);
+      if (tx.hash != calculatedHash) throw new TxHashMismatchError(tx.hash, calculatedHash);
       return calculatedHash;
     });
 


### PR DESCRIPTION
## The problem

When it validates a Reality question, the bot reads the safeSnap transactions from the Snapshot proposal and rebuilds their EIP-712 hashes. It assumed every transaction carries a `mainTransaction` object. When one does not (older Snapshot proposal formats, malformed data, or a proposal crafted to trigger it), destructuring that missing object throws a raw `TypeError`. That is not a validation error, so it escapes the validation catch, escapes the notification, and reaches the top of the processing loop, which shuts the bot down. With `restart: always` in production this becomes a crash loop that blocks every notification.

I hit this on the first real Gnosis SafeSnap proposal I ran through the bot.

## The fix

The transaction check now guards `mainTransaction` and its required fields and throws a `MalformedSafeSnapTxError` (a validation error) instead of a raw `TypeError`. It then follows the path we already use for a proposal we cannot validate: the bot sends the warning notification with the reason, flagged for manual review, and keeps running. A malformed proposal degrades to a flagged warning, never a crash.

## Testing

Two unit cases (a transaction with no `mainTransaction`, and one missing a required field), both expecting `MalformedSafeSnapTxError`. Confirmed end to end against the Gnosis proposal that used to crash the bot: it now sends the warning and stays up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Added validation for incomplete or malformed SafeSnap transactions and safe configurations.
  - Transactions with missing or invalid destinations, calldata, values, operations, or numeric fields now produce clear, indexed validation errors.
  - Invalid safe addresses, network IDs, transaction collections, and null entries are rejected consistently.
  - Validation occurs before transaction hash calculation, preventing malformed data from causing unexpected processing failures or incorrect hash comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->