### PR TITLE
feat: adds a configurable block confirmation depth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,11 @@ MAX_BLOCKS_BATCH_SIZE=100
 # Example: 60000
 #BATCH_COOLDOWN=60000
 
+# Block confirmations to hold back from the chain tip before processing (avoids reorg false positives)
+# Optional, default: 0
+# Example: 2
+#BLOCK_CONFIRMATIONS=
+
 # =====================
 # Notifications Configuration
 # =====================

--- a/src/processing.test.ts
+++ b/src/processing.test.ts
@@ -90,6 +90,13 @@ describe("calculateBlockRange", () => {
     const result = fn(mockSpace, blockNumber, 5n);
     expect(result.toBlock).to.equal(blockNumber - 5n);
   });
+
+  it("should default the confirmations depth to the BLOCK_CONFIRMATIONS env var", () => {
+    const blockNumber = mockSpace.lastProcessedBlock! + 10n;
+    const withDefault = fn(mockSpace, blockNumber);
+    const withEnvConfirmations = fn(mockSpace, blockNumber, BigInt(env.BLOCK_CONFIRMATIONS));
+    expect(withDefault).to.deep.equal(withEnvConfirmations);
+  });
 });
 
 describe("min", () => {

--- a/src/processing.test.ts
+++ b/src/processing.test.ts
@@ -51,14 +51,14 @@ describe("calculateBlockRange", () => {
 
   it("should return the range from lastProcessedBlock up to blockNumber in normal conditions", () => {
     const blockNumber = mockSpace.lastProcessedBlock! + BigInt(env.MAX_BLOCKS_BATCH_SIZE) - 1n;
-    const result = fn(mockSpace, blockNumber);
+    const result = fn(mockSpace, blockNumber, 0n);
     expect(result.fromBlock).to.equal(mockSpace.lastProcessedBlock);
     expect(result.toBlock).to.equal(blockNumber);
   });
 
   it("should limit the range if it is larger than MAX_BOCKS_BATCH_SIZE", () => {
     const blockNumber = mockSpace.lastProcessedBlock! + BigInt(env.MAX_BLOCKS_BATCH_SIZE) + 1000n;
-    const result = fn(mockSpace, blockNumber);
+    const result = fn(mockSpace, blockNumber, 0n);
     expect(result.fromBlock).to.equal(mockSpace.lastProcessedBlock);
     expect(result.toBlock).to.equal(mockSpace.lastProcessedBlock! + BigInt(env.MAX_BLOCKS_BATCH_SIZE));
   });
@@ -69,7 +69,7 @@ describe("calculateBlockRange", () => {
       lastProcessedBlock: null,
     };
     const blockNumber = space.startBlock! + BigInt(env.MAX_BLOCKS_BATCH_SIZE) - 1n;
-    const result = fn(space, blockNumber);
+    const result = fn(space, blockNumber, 0n);
     expect(result.fromBlock).to.equal(space.startBlock);
     expect(result.toBlock).to.equal(blockNumber);
   });
@@ -80,9 +80,15 @@ describe("calculateBlockRange", () => {
       startBlock: mockSpace.lastProcessedBlock! + 5n,
     };
     const blockNumber = space.startBlock! + BigInt(env.MAX_BLOCKS_BATCH_SIZE) - 1n;
-    const result = fn(space, blockNumber);
+    const result = fn(space, blockNumber, 0n);
     expect(result.fromBlock).to.equal(space.startBlock);
     expect(result.toBlock).to.equal(blockNumber);
+  });
+
+  it("should hold back the confirmations depth from the tip", () => {
+    const blockNumber = mockSpace.lastProcessedBlock! + 10n;
+    const result = fn(mockSpace, blockNumber, 5n);
+    expect(result.toBlock).to.equal(blockNumber - 5n);
   });
 });
 

--- a/src/processing.ts
+++ b/src/processing.ts
@@ -145,17 +145,24 @@ export const configurableProcessSpace = async (deps: ConfigurableProcessSpaceDep
  *
  * @param space - The space to calculate the block range for
  * @param blockNumber - The latest block number
+ * @param confirmations - Blocks to hold back from the tip; defaults to the BLOCK_CONFIRMATIONS env var
  * @returns the block range that should be processed
  *
  * @example
  *
  * const { fromBlock, toBlock } = calculateBlockRange(space, blockNumber)
  */
-export const calculateBlockRange = (space: Space, blockNumber: bigint) => {
+export const calculateBlockRange = (
+  space: Space,
+  blockNumber: bigint,
+  confirmations: bigint = BigInt(env.BLOCK_CONFIRMATIONS),
+) => {
   const lastProcessedBlock = space.lastProcessedBlock || space.startBlock;
 
+  const safeHead = blockNumber > confirmations ? blockNumber - confirmations : 0n;
+
   const fromBlock = max(lastProcessedBlock, space.startBlock);
-  const toBlock = min(blockNumber, fromBlock + BigInt(env.MAX_BLOCKS_BATCH_SIZE));
+  const toBlock = min(safeHead, fromBlock + BigInt(env.MAX_BLOCKS_BATCH_SIZE));
 
   return { fromBlock, toBlock };
 };

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -120,6 +120,11 @@ export const schema = {
     example: "200",
     default: 200,
   }),
+  BLOCK_CONFIRMATIONS: num({
+    desc: "Number of block confirmations to hold back from the chain tip before processing, to avoid reorg-driven false-positive / duplicate notifications. 0 = process to the tip.",
+    example: "2",
+    default: 0,
+  }),
   BATCH_COOLDOWN: num({
     desc: "Amount of milliseconds to wait to process a new batch after the previous one was processed",
     example: "60000",


### PR DESCRIPTION
The bot processes up to the chain tip. An event in the tip block that then reorgs out has already been notified, and if its transaction re-mines at a different log index the de-duplication key changes and it notifies again. Reading the volatile tip can also race a lagging RPC node. This is noise rather than a missed event, but for a security monitor the noise matters.

This adds `BLOCK_CONFIRMATIONS`: how many blocks to hold back from the tip before processing. It defaults to `0`, so behaviour is unchanged unless it is set. A small value covers shallow reorgs and the RPC race for a few seconds of latency, which is negligible against the batch cooldown and the governance windows we alert on.

Deploy note: 2 on mainnet is enough; Gnosis wants a higher value, its reorg depth is less characterised and its faster blocks mean a given depth covers less time.

## Testing

`calculateBlockRange` now takes the confirmation depth (defaulting to the env var), so it is unit-tested directly; added a case asserting the range is held back by the configured depth.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional `BLOCK_CONFIRMATIONS` setting to delay processing until blocks receive the configured number of confirmations.
  * Defaults to `0`, preserving immediate processing of the latest blocks when no delay is configured.
  * Confirmation depth can be customized for individual processing operations.

* **Documentation**
  * Documented the new setting, including its default and an example value.

* **Tests**
  * Added coverage confirming that unconfirmed blocks are excluded from processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->