### PR TITLE
fix: labels bond amounts with the chain currency symbol

### DIFF
--- a/src/utils/format.test.ts
+++ b/src/utils/format.test.ts
@@ -31,13 +31,20 @@ describe("formatWei", () => {
   });
 
   it("should correctly humanize units close to the ether", () => {
-    expect(fn(10_000_000_000_000_000n)).to.eql("0.01 ether");
-    expect(fn(100_000_000_000_000_000n)).to.eql("0.1 ether");
-    expect(fn(1_000_000_000_000_000_000n)).to.eql("1 ether");
-    expect(fn(1_256_000_000_000_000_000n)).to.eql("1.256 ether");
-    expect(fn(1_500_000_000_000_000_000n)).to.eql("1.5 ether");
-    expect(fn(10_000_000_000_000_000_000n)).to.eql("10 ether");
-    expect(fn(100_000_000_000_000_000_000n)).to.eql("100 ether");
+    const mainnetChainId = 1;
+    expect(fn(10_000_000_000_000_000n, mainnetChainId)).to.eql("0.01 ETH");
+    expect(fn(100_000_000_000_000_000n, mainnetChainId)).to.eql("0.1 ETH");
+    expect(fn(1_000_000_000_000_000_000n, mainnetChainId)).to.eql("1 ETH");
+    expect(fn(1_256_000_000_000_000_000n, mainnetChainId)).to.eql("1.256 ETH");
+    expect(fn(1_500_000_000_000_000_000n, mainnetChainId)).to.eql("1.5 ETH");
+    expect(fn(10_000_000_000_000_000_000n, mainnetChainId)).to.eql("10 ETH");
+    expect(fn(100_000_000_000_000_000_000n, mainnetChainId)).to.eql("100 ETH");
+  });
+
+  it("should resolve the whole-unit symbol from the provided chain", () => {
+    const gnosisChainId = 100;
+    expect(fn(1_000_000_000_000_000_000n, gnosisChainId)).to.eql("1 XDAI");
+    expect(fn(100_000_000_000_000_000n, gnosisChainId)).to.eql("0.1 XDAI");
   });
 });
 

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,29 +1,32 @@
 import { formatEther, formatGwei, Hex } from "viem";
+import { resolveChain } from "../services/provider";
+import { env } from "./env";
 
 /**
  * Converts a wei amount to a human-readable string in wei, gwei, or ether.
  *
  * - Values less than 0.01 gwei are displayed in wei.
  * - Values from 0.01 gwei up to 0.01 ether are displayed in gwei.
- * - Values equal to or greater than 0.01 ether are displayed in ether.
+ * - Values equal to or greater than 0.01 ether are displayed in the chain's native currency (ETH, xDAI, ...).
  *
  * @param {bigint} wei - The amount in wei to be converted.
+ * @param {number} chainId - Chain whose native currency labels whole units; defaults to the configured CHAIN_ID.
  * @returns {string} - The human-readable string representation of the wei amount.
  *
  * @example
  * formatWei(1_000n); // "1000 wei"
  * formatWei(10_000_000n); // "0.01 gwei"
  * formatWei(100_0000_000n); // "1 gwei"
- * formatWei(100_000_000_000_000_000n); // "0.1 ether"
- * formatWei(1_000_000_000_000_000_000n); // "1 ether"
+ * formatWei(100_000_000_000_000_000n); // "0.1 ETH"
+ * formatWei(1_000_000_000_000_000_000n); // "1 ETH"
  */
 
-export const formatWei = (wei: bigint): string => {
+export const formatWei = (wei: bigint, chainId: number = env.CHAIN_ID): string => {
   const digitCount = wei.toString().length;
 
   if (digitCount < 8) return `${wei.toString()} wei`;
   if (digitCount < 17) return `${formatGwei(wei)} gwei`;
-  return `${formatEther(wei)} ether`;
+  return `${formatEther(wei)} ${resolveChain(chainId).nativeCurrency.symbol}`;
 };
 
 /**


### PR DESCRIPTION
`formatWei` labelled every amount as "ether". On any chain other than Ethereum that is wrong, for example a Gnosis bond shown as `0.1 ether` when it is `0.1 XDAI`.

It now uses the native currency symbol of the configured chain:
- mainnet: `0.1 ETH`
- Gnosis: `0.1 XDAI`

The value was already correct (both use 18 decimals); only the label was hardcoded. Updated the `formatWei` test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Native currency formatting now supports the selected network, with an optional chain selection for accurate symbols.
  * Values use the appropriate whole-unit symbol, such as ETH on Ethereum and XDAI on Gnosis Chain.
* **Bug Fixes**
  * Corrected native currency labels that previously displayed “ether” regardless of network.
* **Tests**
  * Added coverage for network-specific currency symbols and formatting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->