### PR TITLE
fix(templates): clarifies the proposal validation checklist

### DIFF
--- a/templates/email/proposal-incomplete-data-html.ejs
+++ b/templates/email/proposal-incomplete-data-html.ejs
@@ -82,7 +82,7 @@
     <tr>
         <td align="left" style="padding:0;Margin:0;padding-top:5px;padding-bottom:10px">
             <p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:'open sans', 'helvetica neue', helvetica, arial, sans-serif;line-height:16.8px;color:#daf0ff;font-size:14px">
-                The following items <span style="font-weight:600">require manual validation</span>:
+                Automated validation did <span style="font-weight:600">NOT run</span> - verify all of these yourself:
             </p>
         </td>
     </tr>
@@ -92,35 +92,11 @@
             <table width="100%" cellpadding="0" cellspacing="0" role="presentation" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px">
                 <tr>
                     <td valign="top" width="22" style="padding:0;Margin:0;font-size:16px;line-height:16px">
-                        ⚠️
-                    </td>
-                    <td valign="top" style="padding:0;Margin:0">
-                        <p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:'open sans', 'helvetica neue', helvetica, arial, sans-serif;line-height:16.8px;color:#becce5;font-size:12px">
-                            The proposal Safe hash is the keccak256 of the concatenated individual hashes (automated validation unavailable)
-                        </p>
-                    </td>
-                </tr>
-                <tr>
-                    <td height="8" style="padding:0;Margin:0;line-height:8px;font-size:0">&nbsp;</td>
-                    <td height="8" style="padding:0;Margin:0;line-height:8px;font-size:0">&nbsp;</td>
-                </tr>
-                <tr>
-                    <td valign="top" width="22" style="padding:0;Margin:0;font-size:16px;line-height:16px">
-                        ⚠️
-                    </td>
-                    <td valign="top" style="padding:0;Margin:0">
-                        <p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:'open sans', 'helvetica neue', helvetica, arial, sans-serif;line-height:16.8px;color:#becce5;font-size:12px">
-                            The hash embedded in the Reality.eth question matches the proposal Safe hash (automated validation unavailable)
-                        </p>
-                    </td>
-                </tr>
-                <tr>
-                    <td valign="top" width="22" style="padding:0;Margin:0;font-size:16px;line-height:16px">
                         🟡
                     </td>
                     <td valign="top" style="padding:0;Margin:0">
                         <p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:'open sans', 'helvetica neue', helvetica, arial, sans-serif;line-height:16.8px;color:#becce5;font-size:12px">
-                            The proposal passed (per Snapshot results)
+                            Verify the proposal Safe hash equals the keccak256 of the concatenated individual hashes
                         </p>
                     </td>
                 </tr>
@@ -134,7 +110,17 @@
                     </td>
                     <td valign="top" style="padding:0;Margin:0">
                         <p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:'open sans', 'helvetica neue', helvetica, arial, sans-serif;line-height:16.8px;color:#becce5;font-size:12px">
-                            The question was created after the proposal was resolved
+                            Verify the hash embedded in the Reality.eth question matches the proposal Safe hash
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td valign="top" width="22" style="padding:0;Margin:0;font-size:16px;line-height:16px">
+                        🟡
+                    </td>
+                    <td valign="top" style="padding:0;Margin:0">
+                        <p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:'open sans', 'helvetica neue', helvetica, arial, sans-serif;line-height:16.8px;color:#becce5;font-size:12px">
+                            Confirm the proposal passed on Snapshot
                         </p>
                     </td>
                 </tr>
@@ -148,7 +134,21 @@
                     </td>
                     <td valign="top" style="padding:0;Margin:0">
                         <p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:'open sans', 'helvetica neue', helvetica, arial, sans-serif;line-height:16.8px;color:#becce5;font-size:12px">
-                            The proposal meets the DAO’s requirements
+                            Confirm the question was created after the proposal resolved
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td height="8" style="padding:0;Margin:0;line-height:8px;font-size:0">&nbsp;</td>
+                    <td height="8" style="padding:0;Margin:0;line-height:8px;font-size:0">&nbsp;</td>
+                </tr>
+                <tr>
+                    <td valign="top" width="22" style="padding:0;Margin:0;font-size:16px;line-height:16px">
+                        🟡
+                    </td>
+                    <td valign="top" style="padding:0;Margin:0">
+                        <p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:'open sans', 'helvetica neue', helvetica, arial, sans-serif;line-height:16.8px;color:#becce5;font-size:12px">
+                            Confirm the proposal meets the DAO requirements
                         </p>
                     </td>
                 </tr>

--- a/templates/email/proposal-incomplete-data-plain.ejs
+++ b/templates/email/proposal-incomplete-data-plain.ejs
@@ -19,12 +19,12 @@ Please find the details below:
 - Question ID: <%- notification.event.questionId %>
 - Proposal ID: <%- notification.event.snapshotId %>
 
-Manual validation required:
-- ⚠️ The proposal Safe hash is the keccak256 of the concatenated individual hashes (automated validation unavailable)
-- ⚠️ The hash embedded in the Reality.eth question matches the proposal Safe hash (automated validation unavailable)
-- 🟡 The proposal passed (per Snapshot results)
-- 🟡 The question was created after the proposal was resolved
-- 🟡 The proposal meets the DAO’s requirements
+Automated validation did NOT run - verify all of these yourself:
+- Verify the proposal Safe hash equals the keccak256 of the concatenated individual hashes
+- Verify the hash embedded in the Reality.eth question matches the proposal Safe hash
+- Confirm the proposal passed on Snapshot
+- Confirm the question was created after the proposal resolved
+- Confirm the proposal meets the DAO requirements
 
 Best regards,
 Kleros Zodiac Notifications Bot

--- a/templates/email/proposal-valid-html.ejs
+++ b/templates/email/proposal-valid-html.ejs
@@ -87,7 +87,7 @@
     <tr>
         <td align="left" style="padding:0;Margin:0;padding-top:0px;padding-bottom:10px">
             <p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:'open sans', 'helvetica neue', helvetica, arial, sans-serif;line-height:16.8px;color:#daf0ff;font-size:14px">
-                The following items <span style="font-weight:600">require manual validation</span>:
+                Verify these <span style="font-weight:600">manually</span>:
             </p>
         </td>
     </tr>
@@ -101,7 +101,7 @@
                     </td>
                     <td valign="top" style="padding:0;Margin:0">
                         <p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:'open sans', 'helvetica neue', helvetica, arial, sans-serif;line-height:16.8px;color:#becce5;font-size:12px">
-                            The proposal passed (per Snapshot results)
+                            Confirm the proposal passed on Snapshot
                         </p>
                     </td>
                 </tr>
@@ -115,7 +115,7 @@
                     </td>
                     <td valign="top" style="padding:0;Margin:0">
                         <p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:'open sans', 'helvetica neue', helvetica, arial, sans-serif;line-height:16.8px;color:#becce5;font-size:12px">
-                            The question was created after the proposal was resolved
+                            Confirm the question was created after the proposal resolved
                         </p>
                     </td>
                 </tr>
@@ -129,7 +129,7 @@
                     </td>
                     <td valign="top" style="padding:0;Margin:0">
                         <p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:'open sans', 'helvetica neue', helvetica, arial, sans-serif;line-height:16.8px;color:#becce5;font-size:12px">
-                            The proposal meets the DAO’s requirements
+                            Confirm the proposal meets the DAO requirements
                         </p>
                     </td>
                 </tr>

--- a/templates/email/proposal-valid-plain.ejs
+++ b/templates/email/proposal-valid-plain.ejs
@@ -9,14 +9,14 @@ Please find the details below:
 - Question ID: <%- notification.event.questionId %>
 - Proposal ID: <%- notification.event.snapshotId %>
 
-These automated checks have passed:
+These automated checks passed:
 - The proposal Safe hash is the keccak256 of the concatenated individual hashes
 - The hash embedded in the Reality.eth question matches the proposal Safe hash
 
-The following checks need manual action:
-- The proposal passed (per Snapshot results)
-- The question was created after the proposal was resolved
-- The proposal meets the DAO’s requirements
+Verify these manually:
+- Confirm the proposal passed on Snapshot
+- Confirm the question was created after the proposal resolved
+- Confirm the proposal meets the DAO requirements
 
 Best regards,
 Kleros Zodiac Notifications Bot

--- a/templates/slack/proposal-incomplete-data.ejs
+++ b/templates/slack/proposal-incomplete-data.ejs
@@ -16,9 +16,9 @@ Manual review required: treat this as a potential security risk until verified.
 _Question ID_: `<%- notification.event.questionId %>`
 _Proposal ID_: `<%- notification.event.snapshotId %>`
 
-*Manual validation required:*
-• ⚠️ The proposal Safe hash is the keccak256 of the concatenated individual hashes (automated validation unavailable)
-• ⚠️ The hash embedded in the Reality.eth question matches the proposal Safe hash (automated validation unavailable)
-• 🟡 The proposal passed (per Snapshot results)
-• 🟡 The question was created after the proposal was resolved
-• 🟡 The proposal meets the DAO’s requirements
+*Automated validation did NOT run - verify all of these yourself:*
+• 🟡 Verify the proposal Safe hash equals the keccak256 of the concatenated individual hashes
+• 🟡 Verify the hash embedded in the Reality.eth question matches the proposal Safe hash
+• 🟡 Confirm the proposal passed on Snapshot
+• 🟡 Confirm the question was created after the proposal resolved
+• 🟡 Confirm the proposal meets the DAO requirements

--- a/templates/slack/proposal-valid.ejs
+++ b/templates/slack/proposal-valid.ejs
@@ -11,7 +11,7 @@ _Proposal ID_: `<%- notification.event.snapshotId %>`
 🟢 The proposal Safe hash is the keccak256 of the concatenated individual hashes
 🟢 The hash embedded in the Reality.eth question matches the proposal Safe hash
 
-*Manual validation required:*
-🟡 The proposal passed (per Snapshot results)
-🟡 The question was created after the proposal was resolved
-🟡 The proposal meets the DAO’s requirements
+*Verify these manually:*
+🟡 Confirm the proposal passed on Snapshot
+🟡 Confirm the question was created after the proposal resolved
+🟡 Confirm the proposal meets the DAO requirements

--- a/templates/telegram/proposal-incomplete-data.ejs
+++ b/templates/telegram/proposal-incomplete-data.ejs
@@ -16,9 +16,9 @@ Manual review required: treat this as a potential security risk until verified.
 _Question ID_: `<%- notification.event.questionId %>`
 _Proposal ID_: `<%- notification.event.snapshotId %>`
 
-*Manual validation required:*
-⚠️ The proposal Safe hash is the keccak256 of the concatenated individual hashes (automated validation unavailable)
-⚠️ The hash embedded in the Reality.eth question matches the proposal Safe hash (automated validation unavailable)
-🟡 The proposal passed (per Snapshot results)
-🟡 The question was created after the proposal was resolved
-🟡 The proposal meets the DAO’s requirements
+*Automated validation did NOT run - verify all of these yourself:*
+🟡 Verify the proposal Safe hash equals the keccak256 of the concatenated individual hashes
+🟡 Verify the hash embedded in the Reality.eth question matches the proposal Safe hash
+🟡 Confirm the proposal passed on Snapshot
+🟡 Confirm the question was created after the proposal resolved
+🟡 Confirm the proposal meets the DAO requirements

--- a/templates/telegram/proposal-valid.ejs
+++ b/templates/telegram/proposal-valid.ejs
@@ -11,7 +11,7 @@ _Proposal ID_: `<%- notification.event.snapshotId %>`
 🟢 The proposal Safe hash is the keccak256 of the concatenated individual hashes
 🟢 The hash embedded in the Reality.eth question matches the proposal Safe hash
 
-*Manual validation required:*
-🟡 The proposal passed (per Snapshot results)
-🟡 The question was created after the proposal was resolved
-🟡 The proposal meets the DAO’s requirements
+*Verify these manually:*
+🟡 Confirm the proposal passed on Snapshot
+🟡 Confirm the question was created after the proposal resolved
+🟡 Confirm the proposal meets the DAO requirements


### PR DESCRIPTION
The proposal notifications list the validation checks with a status icon, but the items read as statements of fact ("The proposal passed"). On a warning notification, where the bot could not verify anything, "The proposal passed" reads as reassurance, the opposite of the intended message.

This regroups and rewords the checklist:
- A section for checks the bot actually confirmed, so those stay as verified facts.
- A section for checks the reader must do, phrased as actions ("Confirm the proposal passed on Snapshot") so they read as to-dos.
- The unvalidatable case has no confirmed section, which makes clear that nothing was verified.

Applied across the email (html and plain), Telegram and Slack templates, for both the valid and the unvalidatable notifications. No logic change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified proposal validation messages across email, Slack, and Telegram notifications.
  * Clearly distinguishes automated checks that passed from checks requiring manual verification.
  * Added explicit reminders to verify the Safe hash, Reality.eth question hash, Snapshot outcome, question timing, and DAO requirements when automated validation does not run.
  * Updated headings, checklist wording, and visual indicators to make validation status and required actions easier to understand.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->