### PR TITLE
chore(logger): fixes heartbeat log message typos

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -98,14 +98,14 @@ export const configurableInitialize = (deps: ConfigurableInitializeDeps) => {
   });
 
   emitter.on(event.HEARTBEAT_READY, () => {
-    logger.info("Perioc hearbeats ready");
+    logger.info("Periodic heartbeats ready");
   });
 
   emitter.on(event.HEARTBEAT_SENT, () => {
-    logger.info(`Perioc hearbeat sent to ${env.HEARTBEAT_URL}`);
+    logger.info(`Periodic heartbeat sent to ${env.HEARTBEAT_URL}`);
   });
 
   emitter.on(event.HEARTBEAT_FAILED, () => {
-    logger.error(`Perioc hearbeat to ${env.HEARTBEAT_URL} failed`);
+    logger.error(`Periodic heartbeat to ${env.HEARTBEAT_URL} failed`);
   });
 };


### PR DESCRIPTION
The heartbeat log lines read "Perioc hearbeat". Corrected to "Periodic heartbeat" so log-based alerting that matches on "heartbeat" does not miss them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected spelling errors in periodic heartbeat log messages for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->