### PR TITLE
docs(env): fix the stale REALITY_LINK_TEMPLATE default in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -134,7 +134,7 @@ SMTP_UNSUBSCRIBE_EMAIL=
 # Example: https://etherscan.io/tx/{{txHash}}
 #BLOCK_EXPLORER_TX_LINK_TEMPLATE=
 
-# Reality link template (use {{oracleAddress}} and {{questionId}} as placeholders)
-# Optional, default: https://reality.eth.limo/app/#!/question/{{oracleAddress}}-{{questionId}}/token/ETH
-# Example: https://reality.eth.limo/app/#!/question/{{oracleAddress}}-{{questionId}}/token/ETH
+# Reality link template (use {{chainId}}, {{oracleAddress}} and {{questionId}} as placeholders)
+# Optional, default: https://reality.eth.limo/app/#!/network/{{chainId}}/question/{{oracleAddress}}-{{questionId}}
+# Example: https://reality.eth.limo/app/#!/network/{{chainId}}/question/{{oracleAddress}}-{{questionId}}
 #REALITY_LINK_TEMPLATE=


### PR DESCRIPTION
The `.env.example` documented the `REALITY_LINK_TEMPLATE` default as `.../question/{{oracleAddress}}-{{questionId}}/token/ETH`, but the actual default in the code is `.../network/{{chainId}}/question/{{oracleAddress}}-{{questionId}}`. The template gained the `{{chainId}}` placeholder and dropped `/token/ETH`, and the example was never updated.

This fixes the comment and example to match the code default, so a fresh `.env` copied from the example does not reintroduce the old link format.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Reality link template documentation to include the `{{chainId}}` variable.
  * Revised the URL format to use a network-specific path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->